### PR TITLE
#54 ターミナルにログを出力できるように設定

### DIFF
--- a/fproject/settings.py
+++ b/fproject/settings.py
@@ -140,9 +140,15 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "formatters":{
+        "simple":{
+            "format":"%(asctime)s %(levelname)s [%(pathname)s:%(lineno)s] %(message)s",
+        }
+    },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
+            "formatter": "simple",
         },
     },
     "root": {

--- a/fproject/settings.py
+++ b/fproject/settings.py
@@ -135,3 +135,18 @@ STATICFILES_DIRS = [BASE_DIR / "static"]
 
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# ログの設定（開発用）
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "DEBUG",
+    },
+}


### PR DESCRIPTION
## 目的
- 開発の効率を上げるために、ターミナル上にログ出力ができるようにしました。

## 実装の概要/やったこと

- `settings.py` にターミナル上にログが出力される設定を記述しました。

## 保留/やらないこと

- ファイル出力などの本番環境向けのログ設定は、現在のところ実装していません。

## できるようになること（ ~~ユーザ目線~~  開発者目線）

- ログの出力をするコードを記載するとターミナル上にログを出力できるようになりました

例 
signup_views.py
``` python
import logging

logger = logging.getLogger(__name__)
logger.warning("危ない")
```
ターミナル
```bash
app-1         | 2025-02-08 02:20:50,808 WARNING [/usr/src/app/account/views/signup_views.py:29] 危ない
```

## できなくなること（ユーザ目線）

- なし

## 動作確認

- 「できるようになること」の欄で記載したように、ログを出力したいファイルでログ出力の記載をするとターミナル上にログが出力されれることを確認しました。

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
