### PR TITLE
#51 ログイン時の遷移先を初回ログインフラグに基づいて変更する処理を実装

### DIFF
--- a/account/models/user_models.py
+++ b/account/models/user_models.py
@@ -2,6 +2,9 @@ from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, DatabaseError, models
+import logging
+
+logger = logging.getLogger(__name__)
 
 class CustomUserManager(BaseUserManager):
 
@@ -88,3 +91,18 @@ class User(AbstractBaseUser):
             # その他のエラー内容を出力
             print(f"Unexpected error updating profile for user {self.id}: {e}")
             raise
+
+    def update_first_login(self):
+        """
+        初回ログインフラグを更新するメソッド。
+        """
+        try:
+            self.is_first_login = 0
+            self.save()
+            logger.info(f"User {self.id}: Successfully updated first login flag.")
+        except DatabaseError as e:
+            # データベースエラーの内容を出力
+            logger.error(f"Database error updating profile for user {self.id}: {e}")
+        except Exception as e:
+            # その他のエラー内容を出力
+            logger.exception(f"Unexpected error updating profile for user {self.id}: {e}")

--- a/account/views/login_views.py
+++ b/account/views/login_views.py
@@ -16,6 +16,8 @@ class LoginView(LoginView):
         user = self.request.user
 
         if user.is_first_login:
+            # 初回ログインフラグを更新（この処理で is_first_login を False にする）
+            user.update_first_login()
             # 初回ログイン時は設定画面へリダイレクト
             return reverse_lazy("account:setup")
         else:

--- a/account/views/login_views.py
+++ b/account/views/login_views.py
@@ -1,3 +1,4 @@
+from django.urls import reverse_lazy
 from django.contrib.auth.views import LoginView
 
 from ..forms import LoginForm
@@ -5,3 +6,18 @@ from ..forms import LoginForm
 class LoginView(LoginView):
     template_name = "login.html"
     form_class = LoginForm
+
+    def get_success_url(self):
+        """
+        ログイン成功時にユーザーの状態に応じて遷移先を変更する
+        Returns:
+            str: 遷移先のURL（初回ログイン時は設定画面、それ以外はホーム）
+        """
+        user = self.request.user
+
+        if user.is_first_login:
+            # 初回ログイン時は設定画面へリダイレクト
+            return reverse_lazy("account:setup")
+        else:
+            # 2回目以降のログインはホーム画面へリダイレクト
+            return reverse_lazy("goal:home")

--- a/fproject/settings.py
+++ b/fproject/settings.py
@@ -61,9 +61,6 @@ WSGI_APPLICATION = "fproject.wsgi.application"
 # Django のデフォルトの User モデルの代わりに、このモデルが認証システムで使用されます。
 AUTH_USER_MODEL = "account.User"
 
-# ログイン後リダイレクトするURL名を指定
-LOGIN_REDIRECT_URL = "goal:home"
-
 # ログアウト後リダイレクトするURL名を指定
 LOGOUT_REDIRECT_URL = "account:login"
 


### PR DESCRIPTION
## 目的
`Users` テーブルの `is_first_login` の値によって、ログイン後の遷移先を分岐する処理を実装しました。
また、初回ログイン時に `is_first_login` の値が更新されるようにしました。

## 実装の概要/やったこと

- `get_success_url` メソッドを作成し、初回ログインと2回目以降のログイン時に遷移先を変更できるようにしました。
- 初回ログイン時に、ユーザー情報の `is_first_login` の値を更新するための `update_first_login` メソッドを作成しました。

## 保留/やらないこと

- 特にありません。

## できるようになること（ユーザ目線）

- 初回ログイン時に、ユーザー情報追加登録画面に遷移するようになります。
- 2回目以降のログイン時に、ホーム画面に遷移するようになります。

## できなくなること（ユーザ目線）

- 特にありません。

## 動作確認

- [x] 初回ログイン時に、ユーザー情報追加登録画面に遷移すること。
- [x] 2回目以降のログイン時に、ホーム画面に遷移すること。
- [x] 初回ログイン時に、`is_first_login` の値が `0（false）` に更新されること。

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
