### PR TITLE
#13 データベースに登録した年・月の目標を目標参照画面で表示できる

### DIFF
--- a/goal/models/month_goal.py
+++ b/goal/models/month_goal.py
@@ -1,8 +1,9 @@
 import datetime
-from django.db import DatabaseError, models
-from .year_goal import YearGoal
-
 import logging
+
+from django.db import models, DatabaseError
+
+from .year_goal import YearGoal
 
 logger = logging.getLogger(__name__)
 
@@ -116,3 +117,34 @@ class MonthGoal(models.Model):
                 logger.error(f"Skipping month {month} due to database error.")
             except Exception:
                 logger.exception(f"Skipping month {month} due to unexpected error.")
+
+    @classmethod
+    def get_monthly_goals_for_year(cls, year_goal_id):
+        """
+        指定された YearGoal に対して、すべての月目標を取得しリストとして返す
+        Args:
+            year_goal_id (int): 年目標の主キー
+        Returns:
+            list: 月目標のリスト（辞書形式）
+        """
+        try:
+            monthly_goals = cls.objects.filter(year_goal=year_goal_id).order_by('month')
+        except DatabaseError:
+            logger.error(f"Database error while fetching monthly goals for YearGoal ID {year_goal_id}.")
+            return []
+        except Exception as e:
+            logger.exception(f"Unexpected error while fetching monthly goals for YearGoal ID {year_goal_id}: {e}")
+            return []
+
+        # 月の選択肢（表示用の辞書）を取得
+        month_choices_dict = dict(cls.MONTH_CHOICES)
+
+        # 各月目標を辞書形式でリストに追加
+        return [
+            {
+                "month": month_choices_dict.get(goal.month, "N/A"),  # 月
+                "title": goal.title,  # タイトル
+                "status": goal.status,  # 状態
+            }
+            for goal in monthly_goals
+        ]

--- a/goal/models/year_goal.py
+++ b/goal/models/year_goal.py
@@ -68,6 +68,7 @@ class YearGoal(models.Model):
         current_year = timezone.now().year
         return cls.objects.filter(user=user, year__year=current_year).first()
 
+    @classmethod
     def get_year_goal_for_user(cls, user, year):
         """
         指定されたユーザーの特定の年の年目標を取得する

--- a/goal/models/year_goal.py
+++ b/goal/models/year_goal.py
@@ -1,12 +1,12 @@
-from django.db import models
-from django.utils import timezone
 import datetime
-from account.models import User
-
 import logging
 
-logger = logging.getLogger(__name__)
+from django.db import models
+from django.utils import timezone
 
+from account.models import User
+
+logger = logging.getLogger(__name__)
 
 # 現在の年の初日をデフォルト値として返す関数
 def default_year_start():
@@ -67,3 +67,27 @@ class YearGoal(models.Model):
         """
         current_year = timezone.now().year
         return cls.objects.filter(user=user, year__year=current_year).first()
+
+    def get_year_goal_for_user(cls, user, year):
+        """
+        指定されたユーザーの特定の年の年目標を取得する
+        Args:
+            user (User): 目標を取得する対象のユーザー
+            year (datetime.date): 目標を取得する年
+        Returns:
+            YearGoal or None: 該当する年目標が存在すれば YearGoal インスタンスを返し、存在しなければ None を返す
+        """
+        try:
+            return cls.objects.get(user=user, year=year)
+        except cls.DoesNotExist:
+            # 目標が設定されていない場合、ログに記録して None を返す
+            logger.warning(f"[YearGoal] Not found: user_id={user.id}, year={year}")
+            return None
+        except cls.MultipleObjectsReturned:
+            # データの整合性エラー（1つの年に複数の目標が存在する）
+            logger.error(f"[YearGoal] Data integrity issue: Multiple entries found for user_id={user.id}, year={year}")
+            return None
+        except Exception as e:
+            # 予期しないエラーのキャッチ
+            logger.exception(f"[YearGoal] Unexpected error: user_id={user.id}, year={year}, error={e}")
+            return None

--- a/goal/templates/year_goal_detail.html
+++ b/goal/templates/year_goal_detail.html
@@ -6,6 +6,25 @@
     <title>Document</title>
 </head>
 <body>
-    
+    {% if year_goal %}
+        <p>{{ year_goal.year.year }}</p>
+        <p>{{ year_goal.title }}</P>
+        <h2>月次目標</h2>
+        {% if month_goals %}
+            <ul>
+                {% for month_goal in month_goals %}
+                    {% if month_goal.title %}
+                        <li>{{ month_goal.month }}: {{ month_goal.title }}</li>
+                    {% else %}
+                        <li>{{ month_goal.month }}: 未設定</li>
+                    {% endif %}
+                {% endfor %}
+            </ul>
+        {% else %}
+            <p>未設定</p>
+        {% endif %}
+    {% else %}
+        <p>未設定</p>
+    {% endif %}
 </body>
 </html>

--- a/goal/urls.py
+++ b/goal/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import HomeView, CreateYearGoalView, FeedbackView
+from .views import HomeView, CreateYearGoalView, YearGoalDetailView, FeedbackView
 
 
 # 名前空間を設定
@@ -7,6 +7,10 @@ app_name = "goal"
 
 urlpatterns = [
     path("year_goal/create/", CreateYearGoalView.as_view(), name="create_year_goal"),
+    # 年指定なしでアクセス（今年の目標）
+    path("year_goal/detail/", YearGoalDetailView.as_view(), name="year_goal_detail"),
+    # 年を指定した場合
+    path("year_goal/detail/<int:year>/", YearGoalDetailView.as_view(), name="year_goal_detail_year"),
     path("", HomeView.as_view(), name="home"),
     path("feedback/", FeedbackView.as_view(), name="feedback"),
 ]

--- a/goal/views/__init__.py
+++ b/goal/views/__init__.py
@@ -1,3 +1,4 @@
 from .home import HomeView
 from .year_goal.create_year_goal_views import CreateYearGoalView
+from .year_goal.year_goal_detail_views import YearGoalDetailView
 from .feedback import FeedbackView

--- a/goal/views/year_goal/year_goal_detail_views.py
+++ b/goal/views/year_goal/year_goal_detail_views.py
@@ -1,0 +1,66 @@
+import logging
+from datetime import date
+
+from django.contrib import messages
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.views.generic import DetailView
+from django.contrib.auth.mixins import LoginRequiredMixin
+
+from goal.models import YearGoal
+from goal.models.month_goal import MonthGoal
+
+
+logger = logging.getLogger(__name__)
+
+class YearGoalDetailView(LoginRequiredMixin, DetailView):
+    template_name = "year_goal_detail.html"
+    model = YearGoal
+    context_object_name = "year_goal"
+
+    def get_object(self):
+        """
+        URLのパスから年を取得し、その年の年目標を取得する
+        Returns:
+            YearGoal: 指定された年の年目標が存在すれば YearGoal インスタンスを返す
+        """
+        # URLパスから年を取得。指定されない場合は現在の年を使用
+        year = self.kwargs.get("year", date.today().year)
+        # 年をdatetime.dateに変換
+        year_start_date = date(year, 1, 1)
+        # 指定された年の目標を取得
+        year_goal = YearGoal.get_year_goal_for_user(self.request.user, year_start_date)
+        if not year_goal:
+            logger.warning(f"[YearGoal] Not found: user_id={self.request.user.id}, year={year}")
+            return None
+
+        return year_goal
+
+    def get(self, request, *args, **kwargs):
+        """
+        GETリクエスト時に、目標が存在しない場合はリダイレクト
+        """
+        self.object = self.get_object()
+        if self.object is None:
+            messages.warning(request, f"{self.kwargs.get('year', date.today().year)}年の目標はまだ設定されていません。")
+            return redirect(reverse("goal:home"))
+
+        return super().get(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        """
+        テンプレートに渡すコンテキストデータを作成する
+
+        Returns:
+            dict: テンプレートに渡すコンテキストデータ
+        """
+        context = super().get_context_data(**kwargs)
+        year_goal = self.object
+
+        if not year_goal:
+            return context
+
+        # year_goal.id をキーとして月次目標を取得し、コンテキストに追加
+        context["month_goals"] = MonthGoal.get_monthly_goals_for_year(year_goal_id=year_goal.id)
+
+        return context


### PR DESCRIPTION
## 目的
年間目標の詳細画面を作成しました。表示される内容は以下の通りです。
- 年目標のタイトル
- 年目標に紐づく月目標

## 実装の概要/やったこと

- 年目標を表示するための `YearGoalDetailView` クラス（View）を作成しました。
- 年目標のデータを取得するために、`YearGoal` クラス（Model）に `get_year_goal_for_user` メソッドを作成しました。
- 月目標のデータを取得するために、`MonthGoal` クラス（Model）に `get_monthly_goals_for_year` メソッドを作成しました。

## 保留/やらないこと

- 年間目標の編集機能の実装
- 月間目標の詳細画面への遷移機能の実装
- 年間目標が未設定の場合、ホーム画面にリダイレクトされる際の文言を画面に表示する機能 → モーダルなどを使用する予定です。

## できるようになること（ユーザ目線）

- 年目標の詳細画面で、年目標と紐づく月目標の一覧を閲覧できるようになりました。

## できなくなること（ユーザ目線）

- 特にないです。

## 動作確認

1. 今年の年目標を表示
- [x] http://127.0.0.1/goal/year_goal/detail/ にアクセスすると、以下が表示されること
  - 今年の年数
  - 年目標のタイトル
  - 年目標に紐づく月目標のタイトル一覧 
- [x] 年目標が未設定の場合、ホーム画面にリダイレクトされること（下記を記載すると表示される）
   ``` html
    {% if messages %}
    <ul class="messages">
        {% for message in messages %}
            <li class="message {{ message.tags }}">
                {{ message }}
            </li>
        {% endfor %}
    </ul>
  {% endif %}
  ``` 
2. 指定した年目標を表示
- [x] http://127.0.0.1/goal/year_goal/detail/<年数>/ にアクセスすると、以下が表示されること
   - 指定した年の年数
   - 年目標のタイトル
   - 年目標に紐づく月目標のタイトル一覧 
- [x] 年目標が未設定の場合、ホーム画面にリダイレクトされること（下記を記載すると表示される）
   ``` html
    {% if messages %}
    <ul class="messages">
        {% for message in messages %}
            <li class="message {{ message.tags }}">
                {{ message }}
            </li>
        {% endfor %}
    </ul>
  {% endif %}
  ``` 
3. 月目標一覧
- [x] 月目標のタイトルが設定されている場合、該当のタイトルが表示されること
- [x] 月目標のタイトルが未設定の場合、「未設定」と表示されること

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
