### PR TITLE
#21 月目標の有無に応じたホーム画面表示切り替え、年目標詳細ボタン完成

### DIFF
--- a/goal/models/month_goal.py
+++ b/goal/models/month_goal.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 
 from django.db import models, DatabaseError
+from django.utils import timezone
 
 from .year_goal import YearGoal
 
@@ -148,3 +149,23 @@ class MonthGoal(models.Model):
             }
             for goal in monthly_goals
         ]
+
+    @classmethod
+    def get_current_month_goal(cls, user):
+        """
+        YearGoal.year=現在の年となる年目標1件を取得する
+        MonthGoal.month=現在の月となる月目標1件を取得する
+            Args:
+                user: ログインユーザー
+            Returns:
+                MonthGoal.year=現在の月となる月目標1件
+        """
+        current_month = timezone.now().month
+
+        year_goal = YearGoal.get_current_year_goal(user)
+
+        if year_goal is None :
+            return None
+        return cls.objects.filter(
+            year_goal=year_goal, month=current_month
+        ).first()

--- a/goal/templates/home.html
+++ b/goal/templates/home.html
@@ -29,10 +29,9 @@
         <h3>{{ year_goal.year|date:"Y" }}年の目標</h3>
         <p>{{ year_goal.title }}</p>
         <div class="goal-buttons">
-          <form method="get" action="{% url 'goal:year_goal_detail' %}">
-            {% csrf_token %}
-              <button type="submit" class="goal-detail">詳細</button>
-          </form>
+          <a href="{% url 'goal:year_goal_detail' %}"
+            ><button class="goal-detail">詳細</button></a
+          >
           <button class="goal-complete">達成</button>
         </div>
       </div>
@@ -40,12 +39,11 @@
       <div class="goal-new-item">
         <h3>今年の目標がまだありません</h3>
         <p>新しい目標を作成しましょう！</p>
-        <form method="post" action="{% url 'goal:create_year_goal' %}">
-          {% csrf_token %}
-          <div class="goal-buttons">
-            <button type="submit" class="goal-create">新規</button>
-          </div>
-        </form>
+        <div class="goal-buttons">
+          <a href="{% url 'goal:create_year_goal' %}"
+            ><button class="goal-create">新規</button></a
+          >
+        </div>
       </div>
       {% endif %} {% if month_goal %}
       <div class="goal-item">

--- a/goal/templates/home.html
+++ b/goal/templates/home.html
@@ -29,7 +29,10 @@
         <h3>{{ year_goal.year|date:"Y" }}年の目標</h3>
         <p>{{ year_goal.title }}</p>
         <div class="goal-buttons">
-          <button class="goal-detail">詳細</button>
+          <form method="get" action="{% url 'goal:year_goal_detail' %}">
+            {% csrf_token %}
+              <button type="submit" class="goal-detail">詳細</button>
+          </form>
           <button class="goal-complete">達成</button>
         </div>
       </div>
@@ -44,15 +47,21 @@
           </div>
         </form>
       </div>
-      {% endif %}
+      {% endif %} {% if month_goal %}
       <div class="goal-item">
-        <h3>今月の目標</h3>
-        <p>目標の内容</p>
+        <h3>{{ month_goal.month }}月の目標</h3>
+        <p>{{ month_goal.title }}</p>
         <div class="goal-buttons">
           <button class="goal-detail">詳細</button>
           <button class="goal-complete">達成</button>
         </div>
       </div>
+      {% else %}
+      <div class="goal-new-item">
+        <h3>今月の目標がまだありません</h3>
+        <p>まずは年目標を作成しましょう！</p>
+      </div>
+      {% endif %}
     </div>
   </div>
 
@@ -61,6 +70,7 @@
     <h2>やるべきこと</h2>
     <div class="todo-list">
       <div class="todo-item">
+        <h3>""</h3>
         <p>やることの内容</p>
         <div class="todo-buttons">
           <button class="todo-complete">達成</button>

--- a/goal/views/home.py
+++ b/goal/views/home.py
@@ -3,6 +3,7 @@ from django.views.generic import TemplateView, DetailView
 from django.contrib.auth.mixins import LoginRequiredMixin
 from account.models.user_models import User
 from ..models.year_goal import YearGoal
+from ..models.month_goal import MonthGoal
 
 
 # TODO: ホーム画面を表示するビューを作成（仮対応）
@@ -33,6 +34,8 @@ class HomeView(LoginRequiredMixin, TemplateView):
         context["year_goal"] = year_goal
 
         # 今月の目標（1件のみ取得）
+        month_goal = MonthGoal.get_current_month_goal(user)
+        context["month_goal"] = month_goal
 
         # 今月のToDo（すべて取得 & ページネーション）
         return context


### PR DESCRIPTION
## 目的
- 月目標の有無に応じたホーム画面表示切り替え、年目標詳細ボタン完成

## 実装の概要/やったこと

- 今月の月目標の有無に応じたホーム画面表示切り替え
- 年目標詳細ボタンを押すと、/goal/year_goal/detail/に遷移する

## 保留/やらないこと

- なし

## できるようになること（ユーザ目線）

- 今月の目標がある時、今月の目標がホームに表示される
- 今月の目標がない時、目標作成を促すメッセージを表示する
- 今年の目標詳細ボタンを押すと、/goal/year_goal/detail/に遷移する

## できなくなること（ユーザ目線）

- なし

## 動作確認

- 実際に操作し、上記の動作ができることを確認

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #21
- @
