### PR TITLE
#80 年目標を編集画面でデータベースを更新できる

### DIFF
--- a/goal/models/year_goal.py
+++ b/goal/models/year_goal.py
@@ -1,8 +1,9 @@
 import datetime
 import logging
 
-from django.db import models
+from django.db import models, DatabaseError
 from django.utils import timezone
+from django.core.exceptions import ValidationError
 
 from account.models import User
 
@@ -53,6 +54,33 @@ class YearGoal(models.Model):
         self.save()
         # 保存後にインスタンスを返す
         return self
+
+    def update_title(self, newTitle):
+        """
+        目標のタイトルを更新するメソッド
+        Args:
+            newTitle (str): 更新後のタイトル
+        Raises:
+            ValidationError: バリデーションエラーが発生した場合
+            DatabaseError: データベースエラーが発生した場合
+            Exception: その他の予期しないエラーが発生した場合
+        """
+        try:
+            self.title = newTitle
+            self.full_clean()
+            self.save()
+        except ValidationError as e:
+            # バリデーションエラーの内容を出力
+            logger.exception(f"Validation error updating year_goal: {self.id} for user {self.user.id}: {e}")
+            raise
+        except DatabaseError as e:
+            # データベースエラーの内容を出力
+            logger.exception(f"Database error updating year_goal: {self.id} for user {self.user.id}: {e}")
+            raise
+        except Exception as e:
+            # その他のエラー内容を出力
+            logger.exception(f"Unexpected error updating year_goal: {self.id} for user {self.user.id}: {e}")
+            raise
 
     @classmethod
     def get_current_year_goal(cls, user):

--- a/goal/templates/year_goal_detail.html
+++ b/goal/templates/year_goal_detail.html
@@ -8,7 +8,18 @@
 <body>
     {% if year_goal %}
         <p>{{ year_goal.year.year }}</p>
-        <p>{{ year_goal.title }}</P>
+        <!-- 表示モード -->
+        <div id="year-goal-display">
+            <span id="year-goal-text">{{ year_goal.title }}</span>
+            <button onclick="toggleEdit()">編集</button>
+        </div>
+        <!-- 編集モード（非表示） -->
+        <div id="year-goal-form" style="display: none;">
+            <input type="text" id="goal-input" value="{{ year_goal.title }}">
+            <button onclick="saveGoal({{ year_goal.year.year }})">保存</button>
+            <button onclick="toggleEdit()">キャンセル</button>
+            <p id="error-message" style="color: red;"></p> <!-- エラー表示用 -->
+        </div>
         <h2>月次目標</h2>
         {% if month_goals %}
             <ul>
@@ -27,4 +38,47 @@
         <p>未設定</p>
     {% endif %}
 </body>
+<script>
+    function toggleEdit() {
+        let displayDiv = document.getElementById("year-goal-display");
+        let formDiv = document.getElementById("year-goal-form");
+
+        if (displayDiv.style.display === "none") {
+            displayDiv.style.display = "block";
+            formDiv.style.display = "none";
+        } else {
+            displayDiv.style.display = "none";
+            formDiv.style.display = "block";
+        }
+    }
+
+    function saveGoal(year) {
+        let newTitle = document.getElementById("goal-input").value;
+
+        fetch(`/goal/year_goal/${year}/edit/`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRFToken": "{{ csrf_token }}"
+            },
+            body: JSON.stringify({ title: newTitle, year: year })
+        })
+        .then(response => response.json().then(data => ({ status: response.status, body: data })))
+        .then(({ status, body }) => {
+            if (status === 200) {
+                console.log('Success:', body.message);
+                document.getElementById("year-goal-text").textContent = newTitle;
+                document.getElementById("error-message").textContent = "";
+                toggleEdit();
+            } else {
+                // バリデーションエラーを投げる
+                throw body.error;
+            }
+        })
+        .catch(error => {
+            console.error('Error:', error);
+            document.getElementById("error-message").textContent = error.title ? error.title.join(", ") : "保存に失敗しました";
+        });
+    }
+</script>
 </html>

--- a/goal/urls.py
+++ b/goal/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
-from .views import HomeView, CreateYearGoalView, YearGoalDetailView, FeedbackView
+
+from .views import HomeView, CreateYearGoalView, YearGoalDetailView, YearGoalUpdateView, FeedbackView
 
 
 # 名前空間を設定
@@ -11,6 +12,8 @@ urlpatterns = [
     path("year_goal/detail/", YearGoalDetailView.as_view(), name="year_goal_detail"),
     # 年を指定した場合
     path("year_goal/detail/<int:year>/", YearGoalDetailView.as_view(), name="year_goal_detail_year"),
+    # 年目標のタイトルを更新
+    path("year_goal/<int:year>/edit/", YearGoalUpdateView.as_view(), name="year_goal_edit"),
     path("", HomeView.as_view(), name="home"),
     path("feedback/", FeedbackView.as_view(), name="feedback"),
 ]

--- a/goal/views/__init__.py
+++ b/goal/views/__init__.py
@@ -1,4 +1,5 @@
 from .home import HomeView
 from .year_goal.create_year_goal_views import CreateYearGoalView
 from .year_goal.year_goal_detail_views import YearGoalDetailView
+from .year_goal.year_goal_update_views import YearGoalUpdateView
 from .feedback import FeedbackView

--- a/goal/views/year_goal/year_goal_update_views.py
+++ b/goal/views/year_goal/year_goal_update_views.py
@@ -1,0 +1,91 @@
+import datetime
+import logging
+import json
+
+from django.views.generic import UpdateView
+from django.http import JsonResponse
+from goal.forms.year_goal.year_goal_forms import YearGoalForm
+from goal.models import YearGoal
+
+logger = logging.getLogger(__name__)
+
+class YearGoalUpdateView(UpdateView):
+    model = YearGoal
+    form_class = YearGoalForm
+
+    def get_object(self, year):
+        """
+        更新対象の年目標を取得する
+        Returns:
+            YearGoal: 指定された年の年目標が存在すれば YearGoal インスタンスを返す
+        """
+        # 年をdatetime.dateに変換
+        try:
+            year = int(year)
+            year_date = datetime.date(year, 1, 1)
+        except ValueError:
+            logger.warning(f"Invalid year parameter: {year}")
+            return None
+
+        # 指定された年の目標を取得
+        year_goal = YearGoal.get_year_goal_for_user(self.request.user, year_date)
+        if not year_goal:
+            logger.warning(f"[YearGoal] Not found: user_id={self.request.user.id}, year={year}")
+            return None
+
+        return year_goal
+
+    def post(self, request, *args, **kwargs):
+        """
+        年目標を更新するためのAPIエンドポイント
+        Args:
+            request (HttpRequest): クライアントからのリクエスト
+        Returns:
+            JsonResponse:
+                - 成功時: 更新されたタイトルを返す (status=200)
+                - 失敗時: エラーメッセージを返す (status=400)
+        """
+        try:
+            # リクエストボディをJSONとして読み込む
+            data = json.loads(request.body)
+            logger.info(f"Received data: {data}")
+
+            # "title" の取得
+            newTitle = data.get("title")
+
+            # "year" の取得とバリデーション
+            year = data.get("year")
+            if not year:
+                logger.warning("Year parameter is missing.")
+                return JsonResponse({"error": "Year parameter is required."}, status=400)
+
+            # "YearGoal" の取得
+            goal = self.get_object(year)
+            if not goal:
+                return JsonResponse({"error": "YearGoal not found."}, status=404)
+
+            logger.info(f"Updating YearGoal for year {year} and user {request.user}")
+
+            # "YearGoalForm" でバリデーション
+            form = self.form_class(data={"title": newTitle}, instance=goal)
+
+            if form.is_valid():
+                try:
+                    # 年目標を更新
+                    goal.update_title(newTitle)
+                    logger.info("Form validation successful. Data updated.")
+                    return JsonResponse({"title": goal.title}, status=200)
+                except Exception as e:
+                    logger.error(f"Failed to update YearGoal: {e}")
+                    return JsonResponse({"error": {"title": ["保存に失敗しました"]}}, status=400)
+            else:
+                logger.info(f"Form validation failed: {form.errors}")
+                return JsonResponse({"error": form.errors}, status=400)
+
+        except json.JSONDecodeError:
+            logger.warning("Invalid JSON format in request body.")
+            return JsonResponse({"error": {"title": ["保存に失敗しました"]}}, status=400)
+
+        except Exception as e:
+            logger.error(f"Unexpected error in YearGoalUpdateView: {e}")
+            return JsonResponse({"error": {"title": ["保存に失敗しました"]}}, status=400)


### PR DESCRIPTION
## 目的
年目標を編集することができるようになりました

## 実装の概要/やったこと

-  `YearGoalUpdateView` クラスを作成（年目標を編集できるAPIエンドポイントを実装）
- model の `YearGoal` クラスに`update_title` メソッドを追加（年目標のタイトルを更新する処理を実装）
## 保留/やらないこと

- `year_goal_detail.html` に記載されている JavaScript を、他の画面と同様に別ファイルへ移行するのが望ましいです。
（可能であれば、対応をお願いできると助かります）

## できるようになること（ユーザ目線）

- 年目標を編集することができるようになりました。

## できなくなること（ユーザ目線）

- 特にないです。

## 動作確認

- [x] 年目標を編集し、DB の値が正しく更新されること
- [x] タイトルが空の状態で編集しようとすると「このフィールドは必須です。」と表示され、DB の値が更新されないこと

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
