### PR TITLE
Feature/16 DBに登録した今月のToDoをホーム画面に表示する

### DIFF
--- a/goal/models/todo.py
+++ b/goal/models/todo.py
@@ -46,5 +46,5 @@ class Todos(models.Model):
         month_goal = MonthGoal.get_current_month_goal(user)
 
         if month_goal is None:
-            return None
+            return cls.objects.none()
         return cls.objects.filter(month_goal=month_goal).order_by("created_at")

--- a/goal/models/todo.py
+++ b/goal/models/todo.py
@@ -33,3 +33,18 @@ class Todos(models.Model):
     def __str__(self):
         month_goal_title = getattr(self.month_goal, 'title', 'Unknown Title')
         return f"{month_goal_title} - {self.title}"
+
+    @classmethod
+    def get_current_month_todos(cls, user):
+        """
+        現在の月のToDoを全件取得
+        Args:
+            user: ログインユーザー
+        Returns:
+            QuerySet: 今月のToDoリスト
+        """
+        month_goal = MonthGoal.get_current_month_goal(user)
+
+        if month_goal is None:
+            return None
+        return cls.objects.filter(month_goal=month_goal).order_by("created_at")

--- a/goal/templates/home.html
+++ b/goal/templates/home.html
@@ -83,6 +83,25 @@
       {% endfor %}
   </div>
 
+  <!-- ページネーション -->
+  <div class="pagination">
+    <span class="step-links">
+        {% if todos.has_previous %}
+            <a href="?page=1">&laquo; 最初へ</a>
+            <a href="?page={{ todos.previous_page_number }}">前へ</a>
+        {% endif %}
+
+        <span class="current">
+            Page {{ todos.number }} of {{ todos.paginator.num_pages }}.
+        </span>
+
+        {% if todos.has_next %}
+            <a href="?page={{ todos.next_page_number }}">次へ</a>
+            <a href="?page={{ todos.paginator.num_pages }}">最後へ &raquo;</a>
+        {% endif %}
+    </span>
+  </div>
+
   <div class="logout">
     <!-- ログアウトボタン -->
     <form method="post" action="{% url 'account:logout' %}">

--- a/goal/templates/home.html
+++ b/goal/templates/home.html
@@ -69,20 +69,18 @@
   <div class="todo-box">
     <h2>やるべきこと</h2>
     <div class="todo-list">
-      <div class="todo-item">
-        <h3>""</h3>
-        <p>やることの内容</p>
-        <div class="todo-buttons">
-          <button class="todo-complete">達成</button>
+      {% for todo in todos %}
+        <div class="todo-item">
+          <h3>{{ month_goal.month }}月のToDo_{{ todo.id }}</h3>
+            <p>{{ todo.title }}</p>
+            <div class="todo-buttons">
+              <button class="todo-complete">達成</button>
+            </div>
         </div>
-      </div>
-      <div class="todo-item">
-        <p>やることの内容</p>
-        <div class="todo-buttons">
-          <button class="todo-complete">達成</button>
-        </div>
-      </div>
+      {% empty %}
+        <p>今月のToDoはまだありません。</p>
     </div>
+      {% endfor %}
   </div>
 
   <div class="logout">

--- a/goal/views/home.py
+++ b/goal/views/home.py
@@ -41,7 +41,7 @@ class HomeView(LoginRequiredMixin, TemplateView):
 
         # 今月のToDo（すべて取得 & ページネーション）
         todos = Todos.get_current_month_todos(user)
-        paginator = Paginator(todos, 4)  # １ページあたり４件
+        paginator = Paginator(todos, 3)  # １ページあたり４件
         page_number = self.request.GET.get("page")  # URLのパラメータから現在のページ番号を取得
         page_obj = paginator.get_page(page_number)  # 指定ページのオブジェクトを返す
         context["todos"] = page_obj

--- a/goal/views/home.py
+++ b/goal/views/home.py
@@ -41,7 +41,7 @@ class HomeView(LoginRequiredMixin, TemplateView):
 
         # 今月のToDo（すべて取得 & ページネーション）
         todos = Todos.get_current_month_todos(user)
-        paginator = Paginator(todos, 3)  # １ページあたり４件
+        paginator = Paginator(todos, 3)  # １ページあたりの件数
         page_number = self.request.GET.get("page")  # URLのパラメータから現在のページ番号を取得
         page_obj = paginator.get_page(page_number)  # 指定ページのオブジェクトを返す
         context["todos"] = page_obj

--- a/goal/views/home.py
+++ b/goal/views/home.py
@@ -4,6 +4,8 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from account.models.user_models import User
 from ..models.year_goal import YearGoal
 from ..models.month_goal import MonthGoal
+from ..models.todo import Todos
+from django.core.paginator import Paginator
 
 
 # TODO: ホーム画面を表示するビューを作成（仮対応）
@@ -38,4 +40,10 @@ class HomeView(LoginRequiredMixin, TemplateView):
         context["month_goal"] = month_goal
 
         # 今月のToDo（すべて取得 & ページネーション）
+        todos = Todos.get_current_month_todos(user)
+        paginator = Paginator(todos, 4)  # １ページあたり４件
+        page_number = self.request.GET.get("page")  # URLのパラメータから現在のページ番号を取得
+        page_obj = paginator.get_page(page_number)  # 指定ページのオブジェクトを返す
+        context["todos"] = page_obj
+
         return context


### PR DESCRIPTION
## 目的
- DBに登録した今月のToDoをホーム画面に表示する

## 実装の概要/やったこと

- DBに登録した今月のToDoをホーム画面に表示する
- ToDoにページネーションを適用

## 保留/やらないこと

- なし

## できるようになること（ユーザ目線）

- 自分の今月のToDoを表示できる
- ３件ごとにページ送りできる
- ToDoが0件のときは、メッセージ表示

## できなくなること（ユーザ目線）

- なし

## 動作確認

- 今月のToDoがないユーザーは、メッセージが表示されること
- 今月のToDoがあるユーザーは、一覧が表示されること
- ページネーションのすべてのリンクが機能していること
- 今月の目標以外に紐づいたToDoは、表示されないこと

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #16 
- @
