### PR TITLE
#85 「月目標詳細&ToDo関連リスト」画面の月目標取得を実装する

### DIFF
--- a/goal/models/month_goal.py
+++ b/goal/models/month_goal.py
@@ -169,3 +169,32 @@ class MonthGoal(models.Model):
         return cls.objects.filter(
             year_goal=year_goal, month=current_month
         ).first()
+
+    @classmethod
+    def get_specific_month_goal(cls, year_goal, month):
+        """
+        指定された特定の年、月の目標を取得する
+        Args:
+            year_goal (YearGoal): 年目標
+            month (int): 目標を取得する月
+        Returns:
+            MonthGoal or None: 該当する月目標が存在すれば MonthGoal インスタンスを返し、存在しなければ None を返す
+        """
+        try:
+            return cls.objects.get(year_goal = year_goal, month=month)
+        except cls.DoesNotExist as e:
+            # 目標が設定されていない場合、ログに記録して None を返す
+            logger.warning(f"[MonthGoal] Not found: year_goal_id={year_goal.id}, month={month}. Error: {e}")
+            return None
+        except cls.MultipleObjectsReturned as e:
+            # データの整合性エラー（1つの年の1つの月に複数の目標が存在する）
+            logger.error(f"[MonthGoal] Data integrity issue: Multiple entries found for year_goal_id={year_goal.id}, month={month}. Error: {e}")
+            return None
+        except DatabaseError as e:
+            # データベース関連のエラー
+            logger.error(f"[MonthGoal] DatabaseError: year_goal_id={year_goal.id}, month={month}. Error: {e}")
+            return None
+        except Exception as e:
+            # 予期しないエラーのキャッチ
+            logger.exception(f"[MonthGoal] Unexpected error: year_goal_id={year_goal.id}, month={month}. Error: {e}")
+            return None

--- a/goal/templates/month_goal_detail.html
+++ b/goal/templates/month_goal_detail.html
@@ -6,6 +6,7 @@
     <title>Document</title>
 </head>
 <body>
+    <div>年: {{month_goal.year_goal.year.year}}</div>
     <div>月: {{month_goal.month}}</div>
     <div>月目標のタイトル: {{month_goal.title}}</div>
 </body>

--- a/goal/templates/month_goal_detail.html
+++ b/goal/templates/month_goal_detail.html
@@ -6,6 +6,7 @@
     <title>Document</title>
 </head>
 <body>
-    
+    <div>月: {{month_goal.month}}</div>
+    <div>月目標のタイトル: {{month_goal.title}}</div>
 </body>
 </html>

--- a/goal/urls.py
+++ b/goal/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import HomeView, CreateYearGoalView, YearGoalDetailView, YearGoalUpdateView, FeedbackView
+from .views import HomeView, CreateYearGoalView, YearGoalDetailView, YearGoalUpdateView, MontGoalDetailView, FeedbackView
 
 
 # 名前空間を設定
@@ -14,6 +14,10 @@ urlpatterns = [
     path("year_goal/detail/<int:year>/", YearGoalDetailView.as_view(), name="year_goal_detail_year"),
     # 年目標のタイトルを更新
     path("year_goal/<int:year>/edit/", YearGoalUpdateView.as_view(), name="year_goal_edit"),
+    # 年指定なしでアクセス（月の目標）
+    path("year_goal/month_goal/<int:month>/", MontGoalDetailView.as_view(), name="month_goal_detail"),
+    # 年を指定した場合（月の目標）
+    path("year_goal/<int:year>/month_goal/<int:month>/", MontGoalDetailView.as_view(), name="month_goal_detail_specific_year"),
     path("", HomeView.as_view(), name="home"),
     path("feedback/", FeedbackView.as_view(), name="feedback"),
 ]

--- a/goal/views/__init__.py
+++ b/goal/views/__init__.py
@@ -2,4 +2,5 @@ from .home import HomeView
 from .year_goal.create_year_goal_views import CreateYearGoalView
 from .year_goal.year_goal_detail_views import YearGoalDetailView
 from .year_goal.year_goal_update_views import YearGoalUpdateView
+from .month_goal.month_goal_detail_views import MontGoalDetailView
 from .feedback import FeedbackView

--- a/goal/views/month_goal/month_goal_detail_views.py
+++ b/goal/views/month_goal/month_goal_detail_views.py
@@ -1,0 +1,73 @@
+import logging
+from datetime import date
+
+from django.contrib import messages
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.views.generic import DetailView
+from django.contrib.auth.mixins import LoginRequiredMixin
+
+from goal.models.month_goal import MonthGoal
+from goal.models.year_goal import YearGoal
+
+logger = logging.getLogger(__name__)
+
+class MontGoalDetailView(LoginRequiredMixin, DetailView):
+    template_name = "month_goal_detail.html"
+    model = MonthGoal
+    context_object_name = "month_goal"
+
+    def get_object(self):
+        """
+        URLのパスから年を取得し、その年の年目標を取得する
+        Returns:
+            month_goal: 指定された年の月目標が存在すれば MonthGoal インスタンスを返す
+        """
+        year = self.kwargs.get("year", date.today().year)
+        month = self.kwargs.get("month")
+
+        # URL パラメータに month が設定されているか確認
+        if not month:
+            logger.warning(f"Month not provided in URL: year={year}")
+            return None
+
+        # 年をdatetime.dateに変換
+        year_start_date = date(year, 1, 1)
+        # 指定された年の目標を取得
+        year_goal = YearGoal.get_year_goal_for_user(self.request.user, year_start_date)
+        if not year_goal:
+            logger.warning(f"[YearGoal] Not found: user_id={self.request.user.id}, year={year}")
+            return None
+
+        # 月目標を取得
+        month_goal = MonthGoal.get_specific_month_goal(year_goal=year_goal, month=month)
+
+        return month_goal
+
+    def get(self, request, *args, **kwargs):
+        """
+        GETリクエスト時に、目標が存在しない場合はリダイレクト
+        """
+        self.object = self.get_object()
+        if self.object is None or self.object.title is None:
+            messages.warning(request, f"{self.kwargs.get('year', date.today().year)}年の{self.kwargs.get('month')}月の目標はまだ設定されていません。")
+            return redirect(reverse("goal:home"))
+
+        return super().get(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        """
+        テンプレートに渡すコンテキストデータを作成する
+
+        Returns:
+            dict: テンプレートに渡すコンテキストデータ
+        """
+        context = super().get_context_data(**kwargs)
+        month_goal = self.object
+
+        if not month_goal:
+            return context
+
+        # TODO: month_goal.id をキーとしてTODOを取得し、コンテキストに追加
+
+        return context


### PR DESCRIPTION
## 目的
- 月目標詳細&ToDo関連リスト画面で、指定された月の目標データを取得し、正しく表示できるようにしました。

## 実装の概要/やったこと

-  `MontGoalDetailView` クラスを作成
（「月目標詳細&ToDo関連リスト」画面のURLを叩いた際に、月目標を取得する処理を実装）
- model の `MonthGoal` クラスに `get_specific_month_goal` メソッドを追加
（指定された年・月の目標を取得するメソッドを実装）

## 保留/やらないこと

- 月目標に紐づく ToDo の取得（今回は未実装）

## できるようになること（ユーザ目線）

- 「月目標詳細&ToDo関連リスト」画面にアクセスすると、指定された月の目標を確認できるようになりました。

## できなくなること（ユーザ目線）

- 特にないです。

## 動作確認

1. 年目標（今年）に紐づく指定した月の目標を表示
- [x] http://127.0.0.1/goal/year_goal/month_goal/2/ にアクセスすると、以下が表示されること
  - 今年の年数
  - 月
  - 月目標のタイトル 
2.  年目標（指定）に紐づく指定した月の目標を表示
-  [x] http://127.0.0.1/goal/year_goal/detail/<年数>/month_goal/2/ にアクセスすると、以下が表示されること
   - 指定した年の年数
   - 月
   - 月目標のタイトル
3.  月目標が未設定の場合、ホーム画面にリダイレクトされること（下記を記載すると表示される）
- [x] 
   ``` html
    {% if messages %}
    <ul class="messages">
        {% for message in messages %}
            <li class="message {{ message.tags }}">
                {{ message }}
            </li>
        {% endfor %}
    </ul>
   {% endif %}
  ``` 

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
