### PR TITLE
#15 Todoの情報をデータベースに登録できる

### DIFF
--- a/goal/forms/todo/todo_forms.py
+++ b/goal/forms/todo/todo_forms.py
@@ -1,0 +1,31 @@
+from django import forms
+
+from ...models import Todos
+
+class TodoForm(forms.ModelForm):
+    class Meta:
+        model = Todos
+        fields = ("title",)
+
+    def clean_title(self):
+        """
+        タイトルのバリデーションを行う。
+        Returns: titleを返す
+        Raises:
+            タイトル空白: forms.ValidationError: 文字を入れてください
+            タイトルスペースのみ: form.ValidationError: 入力できない文字列です
+            タイトル50字以上: forms.ValidationError: ５０字以内で入力してください
+        """
+        title = self.cleaned_data.get("title")
+
+        if not isinstance(title, str):
+            raise forms.ValidationError("タイトルは文字列で入力してください。")
+        if not (title := title.strip()):
+            raise forms.ValidationError(
+                "タイトルは空白文字のみで入力しないでください。"
+            )
+        if len(title) > 50:
+            raise forms.ValidationError("タイトルは50文字以内で入力してください。")
+
+        return title
+

--- a/goal/forms/todo/todo_forms.py
+++ b/goal/forms/todo/todo_forms.py
@@ -10,22 +10,17 @@ class TodoForm(forms.ModelForm):
     def clean_title(self):
         """
         タイトルのバリデーションを行う。
-        Returns: titleを返す
-        Raises:
-            タイトル空白: forms.ValidationError: 文字を入れてください
-            タイトルスペースのみ: form.ValidationError: 入力できない文字列です
-            タイトル50字以上: forms.ValidationError: ５０字以内で入力してください
-        """
-        title = self.cleaned_data.get("title")
+        Returns:
+            str: title
 
-        if not isinstance(title, str):
-            raise forms.ValidationError("タイトルは文字列で入力してください。")
-        if not (title := title.strip()):
-            raise forms.ValidationError(
-                "タイトルは空白文字のみで入力しないでください。"
-            )
-        if len(title) > 50:
-            raise forms.ValidationError("タイトルは50文字以内で入力してください。")
+        Raises:
+            forms.ValidationError: タイトルが空白文字のみの場合にエラーを発生させる。
+        """
+        title = self.cleaned_data.get("title", "")
+        checkTitle = title.strip()
+
+        if not checkTitle:
+            raise forms.ValidationError("タイトルは空白文字のみで入力しないでください。")
 
         return title
 

--- a/goal/models/todo.py
+++ b/goal/models/todo.py
@@ -1,6 +1,10 @@
-from django.db import models
+import logging
+
+from django.db import models, DatabaseError
 
 from .month_goal import MonthGoal
+
+logger = logging.getLogger(__name__)
 
 # todosテーブルの作成
 class Todos(models.Model):
@@ -48,3 +52,21 @@ class Todos(models.Model):
         if month_goal is None:
             return cls.objects.none()
         return cls.objects.filter(month_goal=month_goal).order_by("created_at")
+
+    @classmethod
+    def create_todo(cls, title, month_goal):
+        """
+        指定された月のToDoを作成
+        Args:
+            title: Todoのタイトル
+            month_goal: 月目標
+        """
+        try:
+            # 新しいTodoを作成
+            cls.objects.create(title=title, month_goal=month_goal)
+        except DatabaseError as e:
+            logger.error(f"Database error occurred while creating Todo for MonthGoal ID {month_goal.id} with title '{title}': {e}")
+            raise
+        except Exception as e:
+            logger.exception(f"An unexpected error occurred while creating Todo for MonthGoal ID {month_goal.id} with title '{title}': {e}")
+            raise

--- a/goal/templates/todo_create.html
+++ b/goal/templates/todo_create.html
@@ -6,6 +6,10 @@
     <title>Document</title>
 </head>
 <body>
-    
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">送信</button>
+    </form>
 </body>
 </html>

--- a/goal/urls.py
+++ b/goal/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import HomeView, CreateYearGoalView, YearGoalDetailView, YearGoalUpdateView, MontGoalDetailView, FeedbackView
+from .views import HomeView, CreateYearGoalView, YearGoalDetailView, YearGoalUpdateView, MontGoalDetailView, TodoCreateView, FeedbackView
 
 
 # 名前空間を設定
@@ -18,6 +18,10 @@ urlpatterns = [
     path("year_goal/month_goal/<int:month>/", MontGoalDetailView.as_view(), name="month_goal_detail"),
     # 年を指定した場合（月の目標）
     path("year_goal/<int:year>/month_goal/<int:month>/", MontGoalDetailView.as_view(), name="month_goal_detail_specific_year"),
+    # Todo作成画面（年指定なし）
+    path("year_goal/month_goal/<int:month>/todo/create/", TodoCreateView.as_view(), name="create_todo"),
+    # Todo作成画面（年指定あり）
+    path("year_goal/<int:year>/month_goal/<int:month>/todo/create/", TodoCreateView.as_view(), name="create_todo_specific_year"),
     path("", HomeView.as_view(), name="home"),
     path("feedback/", FeedbackView.as_view(), name="feedback"),
 ]

--- a/goal/views/__init__.py
+++ b/goal/views/__init__.py
@@ -3,4 +3,5 @@ from .year_goal.create_year_goal_views import CreateYearGoalView
 from .year_goal.year_goal_detail_views import YearGoalDetailView
 from .year_goal.year_goal_update_views import YearGoalUpdateView
 from .month_goal.month_goal_detail_views import MontGoalDetailView
+from .todo.todo_create_views import TodoCreateView
 from .feedback import FeedbackView

--- a/goal/views/todo/todo_create_views.py
+++ b/goal/views/todo/todo_create_views.py
@@ -1,0 +1,78 @@
+from datetime import date
+import logging
+
+from django.urls import reverse
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic.edit import FormView
+
+from goal.forms.todo.todo_forms import TodoForm
+from ...models import YearGoal, MonthGoal, Todos
+
+logger = logging.getLogger(__name__)
+
+class TodoCreateView(LoginRequiredMixin, FormView):
+    model = Todos
+    template_name = "todo_create.html"
+    form_class = TodoForm
+
+    def form_valid(self, form):
+        """
+        フォームが正常に送信された場合に呼び出され、Todoの作成を行うメソッド。
+        - ログインユーザーを取得し、指定された年と月に対応する年目標および月目標を取得。
+        - フォームから取得したタイトルを使って、Todoを作成します。
+
+        Returns:
+            HttpResponseRedirect: form_validが正常に実行されると、フォームの送信後に成功ページへリダイレクトされます。
+        """
+        user = self.request.user
+        # 年が指定されていなければ現在の年を使用
+        year = self.kwargs.get('year', date.today().year)
+        month = self.kwargs.get("month")
+
+        year_start_date = date(year, 1, 1)
+
+        # 年目標を取得
+        year_goal = YearGoal.get_year_goal_for_user(user=user, year=year_start_date)
+        if not year_goal:
+            logger.warning(f"[YearGoal] Not found: user_id={self.request.user.id}, year={year}")
+            form.add_error(None, f"指定された年目標（{year}）が見つかりませんでした。")
+            return self.form_invalid(form)
+        # 月目標を取得
+        month_goal = MonthGoal.get_specific_month_goal(year_goal=year_goal, month=month)
+        if not month_goal:
+            logger.warning(f"[MonthGoal] Not found: user_id={self.request.user.id}, year_goal={year_goal}, month={month}")
+            form.add_error(None, f"指定された月目標（{month}月）が見つかりませんでした。もう一度お試しください。")
+            return self.form_invalid(form)
+
+        title = form.cleaned_data["title"]
+        try:
+            # Todoを作成
+            Todos.create_todo(title=title, month_goal=month_goal)
+        except Exception as e:
+            logger.exception(f"Todoの作成中にエラーが発生しました: {e}")
+            form.add_error(None, "Todoの作成に失敗しました。もう一度お試しください。")
+            return self.form_invalid(form)
+
+        return super().form_valid(form)
+
+    def form_invalid(self, form):
+        # エラーメッセージをビューで表示
+        return super().form_invalid(form)
+
+    def get_success_url(self):
+        """
+        Todo作成後、遷移先のURLを決定するメソッド。
+        - 年が指定されている場合は、指定された年と月に対応する月目標詳細画面へ遷移。
+        - 年が指定されていない場合は、現在の年の月目標詳細画面へ遷移。
+
+        Returns:
+            str: 遷移先のURL。年が指定されていれば、指定された年と月に対応する月目標詳細画面へ、
+                そうでなければ現在の年の月目標の詳細画面へ遷移します。
+        """
+        year = self.kwargs.get('year')
+        month = self.kwargs.get("month")
+
+        if year:
+            return reverse("goal:month_goal_detail_specific_year", kwargs={"year": year, "month": month})
+        else:
+            return reverse("goal:month_goal_detail", kwargs={"month": month})


### PR DESCRIPTION
## 目的
- Todoの情報をデータベースに登録できるようにしました。 

## 実装の概要/やったこと

- `TodoCreateView` クラスの作成
- `Todos` クラスに DBに新規のTodo を作成するための `create_todo` メソッドを作成
- `TodoForm` クラスを作成

## 保留/やらないこと

- `todo_create.html` の整備

## できるようになること（ユーザ目線）

- Todoを作成できるようになりました

## できなくなること（ユーザ目線）

- 特にないです

## 動作確認

1. `http://127.0.0.1/goal/year_goal/month_goal/<int: 月>/todo/create/` で訪れた画面にて、ToDo を作成する
   - [x] 指定した月の目標に紐づいた ToDo がデータベースに登録されること
   - [x] 複数登録できること

2. `http://127.0.0.1/goal/year_goal/<int: 年>/month_goal/<int: 月>/todo/create/` で訪れた画面にて、ToDo を作成する
   - [x] 指定した年の目標に関連し、指定した月の目標に結びついた ToDo がデータベースに登録されること
   - [x] 複数登録できること

3. `http://127.0.0.1/goal/year_goal/month_goal/<int: 月>/todo/create/`（URL は 1, 2 どちらでも OK）でバリデーションに引っかかる値で登録する
   - [x] フォームに値がない状態で登録を試みた結果、エラーメッセージが表示され、登録されないこと
   - [x] 51 文字で登録を試みた結果、エラーメッセージが表示され、登録されないこと
   - [x] 空白文字のみを入力した状態で登録を試みた結果、エラーメッセージが表示され、登録されないこと


## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
