### PR TITLE
#92 月目標のタイトルが「None」の場合、月目標の詳細画面に遷移できない問題を解決する

### DIFF
--- a/goal/views/month_goal/month_goal_detail_views.py
+++ b/goal/views/month_goal/month_goal_detail_views.py
@@ -49,7 +49,7 @@ class MontGoalDetailView(LoginRequiredMixin, DetailView):
         GETリクエスト時に、目標が存在しない場合はリダイレクト
         """
         self.object = self.get_object()
-        if self.object is None or self.object.title is None:
+        if self.object is None:
             messages.warning(request, f"{self.kwargs.get('year', date.today().year)}年の{self.kwargs.get('month')}月の目標はまだ設定されていません。")
             return redirect(reverse("goal:home"))
 


### PR DESCRIPTION
## 目的
月目標のタイトルが「None」の場合、月目標の詳細画面に遷移できないバグがあったので解消しました。

## 実装の概要/やったこと
`MontGoalDetailView` クラスの `get` メソッドで
タイトルが「None」の場合も、ホーム画面にリダイレクトされるようになっていたため、修正しました。

対応方針は issue に記載しています。
- [月目標のタイトルが「None」の場合、月目標の詳細画面に遷移できない問題を解決する](https://github.com/2025-Winter-Hackathon-F-team/2025winterF/issues/92)

## 保留/やらないこと

特にないです

## できるようになること（ユーザ目線）

月目標のタイトルが「None」の場合でも、月目標の詳細画面に遷移できるようになりました。

## できなくなること（ユーザ目線）

特にないです

## 動作確認

1. 月目標のタイトルが設定されている場合
- [x] `http://127.0.0.1/goal/year_goal/month_goal/2/`
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/2/`

2. 月目標のタイトルが「None」（設定されていない）場合
※年目標作成月は「2月」
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/1/` 
→ 1月：ホーム画面にリダイレクト
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/2/` 
→ 2月：月目標詳細画面に遷移
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/3/` 
→ 3月：月目標詳細画面に遷移
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/4/` 
→ 4月：月目標詳細画面に遷移
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/5/` 
→ 5月：月目標詳細画面に遷移
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/6/`
→ 6月：月目標詳細画面に遷移
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/7/`
→ 7月：月目標詳細画面に遷移
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/8/`
→ 8月：月目標詳細画面に遷移
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/9/`
→ 9月：月目標詳細画面に遷移
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/10/`
→ 10月：月目標詳細画面に遷移
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/11/`
→ 11月：月目標詳細画面に遷移
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/12/`
→ 12月：月目標詳細画面に遷移
- [x] `http://127.0.0.1/goal/year_goal/2025/month_goal/13/`
→ 13月以降~：ホーム画面にリダイレクト

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
