### PR TITLE
#94 月目標詳細画面にTodoリストを表示されるようにする

### DIFF
--- a/goal/models/todo.py
+++ b/goal/models/todo.py
@@ -70,3 +70,22 @@ class Todos(models.Model):
         except Exception as e:
             logger.exception(f"An unexpected error occurred while creating Todo for MonthGoal ID {month_goal.id} with title '{title}': {e}")
             raise
+
+    @classmethod
+    def get_todos_for_month_goal(cls, month_goal):
+        """
+        指定された MonthGoal に対して、すべてのTodoを取得しリストとして返す
+        Args:
+            month_goal: 月目標
+        Returns:
+            QuerySet: Todo のクエリセット
+        """
+        try:
+            todos = cls.objects.filter(month_goal=month_goal).order_by("id")
+            return todos
+        except DatabaseError:
+            logger.error(f"Database error while fetching todos for MonthGoal ID {month_goal.id}.")
+        except Exception as e:
+            logger.exception(f"Unexpected error while fetching todos for MonthGoal ID {month_goal.id}: {e}")
+
+        return cls.objects.none()

--- a/goal/templates/month_goal_detail.html
+++ b/goal/templates/month_goal_detail.html
@@ -9,5 +9,15 @@
     <div>年: {{month_goal.year_goal.year.year}}</div>
     <div>月: {{month_goal.month}}</div>
     <div>月目標のタイトル: {{month_goal.title}}</div>
+    <h2>Todos</h2>
+        {% if todos %}
+            <ul>
+                {% for todo in todos %}
+                    <li>タイトル: {{ todo.title }}</li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            <p>未設定</p>
+        {% endif %}
 </body>
 </html>

--- a/goal/views/month_goal/month_goal_detail_views.py
+++ b/goal/views/month_goal/month_goal_detail_views.py
@@ -8,6 +8,7 @@ from django.views.generic import DetailView
 from django.contrib.auth.mixins import LoginRequiredMixin
 
 from goal.models.month_goal import MonthGoal
+from goal.models.todo import Todos
 from goal.models.year_goal import YearGoal
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,8 @@ class MontGoalDetailView(LoginRequiredMixin, DetailView):
         if not month_goal:
             return context
 
-        # TODO: month_goal.id をキーとしてTODOを取得し、コンテキストに追加
+        # month_goal に紐づくTodoを取得し、コンテキストに追加
+        todos = Todos.get_todos_for_month_goal(month_goal)
+        context["todos"] = todos
 
         return context


### PR DESCRIPTION
## 目的
月目標詳細画面にTodoリストを表示されるようにしました

## 実装の概要/やったこと

- `Todos` クラスに、指定された月目標に紐づくすべての Todo を取得する `get_todos_for_month_goal` メソッドを作成
- `MontGoalDetailView` クラスの `get_context_data` メソッドで Todo のリストを取得し、
画面に Todo のデータを渡せるように修正

## 保留/やらないこと

- 特にないです

## できるようになること（ユーザ目線）

- 月目標詳細画面で、登録済みの Todo を閲覧できるようになる

## できなくなること（ユーザ目線）

- 特にないです

## 動作確認

1. 指定された月目標に紐づく Todo が登録されている場合
- [x] 登録されているTodoが表示されること
URL（年指定なし）: `http://127.0.0.1/goal/year_goal/month_goal/<int: 月>/`
- [x] 登録されているTodoが表示されること
URL（年指定あり）: `http://127.0.0.1/goal/year_goal/<int: 年>/month_goal/<int: 月>/`
2. 指定された月目標に紐づく Todo が登録されていない場合
- [x] Todoが表示されず、「未設定」と表示されること
URL（年指定なし）: `http://127.0.0.1/goal/year_goal/month_goal/<int: 月>/`
- [x] Todoが表示されず、「未設定」と表示されること
URL（年指定あり）: `http://127.0.0.1/goal/year_goal/<int: 年>/month_goal/<int: 月>/`
## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
