### PR TITLE
Feature/88 year_goal_detail.htmlのデザイン

### DIFF
--- a/goal/models/month_goal.py
+++ b/goal/models/month_goal.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from .year_goal import YearGoal
 
+
 logger = logging.getLogger(__name__)
 
 # month_goalsテーブルの作成

--- a/goal/templates/year_goal_detail.html
+++ b/goal/templates/year_goal_detail.html
@@ -42,7 +42,13 @@
       <tbody>
         {% for month_goal in month_goals %}
         <tr>
-          <td>{{ month_goal.month }}</td>
+          <td>
+            <a
+              href="{% url 'goal:month_goal_detail' month_goal.month|slice:':-1'|add:0 %}"
+            >
+              {{ month_goal.month }}
+            </a>
+          </td>
           <td>{{ month_goal.title|default:"未設定" }}</td>
           <td>{{ month_goal.status }}</td>
         </tr>
@@ -56,6 +62,23 @@
     {% else %}
     <p>月目標がありません。</p>
     {% endif %}
+  </div>
+
+  <!-- ページネーション -->
+  <div class="pagination">
+    <span class="step-links">
+      {% if month_goals.has_previous %}
+      <a href="?page={{ month_goals.previous_page_number }}">前へ</a>
+      {% endif %}
+
+      <span class="current">
+        Page {{ month_goals.number }} of {{ month_goals.paginator.num_pages }}.
+      </span>
+
+      {% if month_goals.has_next %}
+      <a href="?page={{ month_goals.next_page_number }}">次へ</a>
+      {% endif %}
+    </span>
   </div>
 </div>
 {% endblock content %} {% block script %}

--- a/goal/templates/year_goal_detail.html
+++ b/goal/templates/year_goal_detail.html
@@ -82,6 +82,22 @@
       {% endif %}
     </span>
   </div>
+
+  <!-- ホームボタン -->
+  <div class="home">
+    <form method="get" action="{% url 'goal:home' %}">
+      {% csrf_token %}
+      <button type="submit" class="home-button">Home</button>
+    </form>
+  </div>
+
+  <div class="logout">
+    <!-- ログアウトボタン -->
+    <form method="post" action="{% url 'account:logout' %}">
+      {% csrf_token %}
+      <button type="submit" class="logout-button">Logout</button>
+    </form>
+  </div>
 </div>
 {% endblock content %} {% block script %}
 <script>

--- a/goal/templates/year_goal_detail.html
+++ b/goal/templates/year_goal_detail.html
@@ -1,84 +1,67 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
-</head>
-<body>
+{% extends "base.html" %} {% load static %} {% block title %} 年目標詳細 
+{% endblock title %} {% block head %}
+<link rel="stylesheet" href="{% static 'css/year_goal_detail.css' %}" />
+{% endblock head %} {% block content %}
+<div class="year-goal-container">
+  <!-- 年目標エリア -->
+  <div class="year-goal-box">
     {% if year_goal %}
-        <p>{{ year_goal.year.year }}</p>
-        <!-- 表示モード -->
-        <div id="year-goal-display">
-            <span id="year-goal-text">{{ year_goal.title }}</span>
-            <button onclick="toggleEdit()">編集</button>
-        </div>
-        <!-- 編集モード（非表示） -->
-        <div id="year-goal-form" style="display: none;">
-            <input type="text" id="goal-input" value="{{ year_goal.title }}">
-            <button onclick="saveGoal({{ year_goal.year.year }})">保存</button>
-            <button onclick="toggleEdit()">キャンセル</button>
-            <p id="error-message" style="color: red;"></p> <!-- エラー表示用 -->
-        </div>
-        <h2>月次目標</h2>
-        {% if month_goals %}
-            <ul>
-                {% for month_goal in month_goals %}
-                    {% if month_goal.title %}
-                        <li>{{ month_goal.month }}: {{ month_goal.title }}</li>
-                    {% else %}
-                        <li>{{ month_goal.month }}: 未設定</li>
-                    {% endif %}
-                {% endfor %}
-            </ul>
-        {% else %}
-            <p>未設定</p>
-        {% endif %}
-    {% else %}
-        <p>未設定</p>
-    {% endif %}
-</body>
-<script>
-    function toggleEdit() {
-        let displayDiv = document.getElementById("year-goal-display");
-        let formDiv = document.getElementById("year-goal-form");
+    <p>{{ year_goal.year.year }}年</p>
+    <!-- 表示モード -->
+    <div id="year-goal-display">
+      <span id="year-goal-text">{{ year_goal.title }}</span>
+      <button class="edit-button" onclick="toggleEdit()">編集</button>
+    </div>
+    <!-- 編集モード（非表示） -->
+    <div id="year-goal-form" style="display: none">
+      <input type="text" id="goal-input" value="{{ year_goal.title }}" />
+      <button class="save-button" onclick="saveGoal({{ year_goal.year.year }})">
+        保存
+      </button>
+      <button class="cancel-button" onclick="toggleEdit()">キャンセル</button>
+      <p id="error-message" style="color: red"></p>
+      <!-- エラー表示用 -->
+    </div>
+  </div>
 
-        if (displayDiv.style.display === "none") {
-            displayDiv.style.display = "block";
-            formDiv.style.display = "none";
-        } else {
-            displayDiv.style.display = "none";
-            formDiv.style.display = "block";
-        }
-    }
+  <!-- 月目標リスト -->
+  <div class="month-goal-box">
+    <h2>月次目標</h2>
+    <table>
+      <!-- {% if month_goals %} -->
+      <thead>
+        <tr>
+          <th>月</th>
+          <th>タイトル</th>
+          <th>状態</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for month_goal in month_goals %}
+        <!-- {% if month_goal.title %} -->
+        <tr>
+          <!-- <td>{{ month_goal.month }}: {{ month_goal.title }}</td> -->
+          <td>{{ month_goal.month }}</td>
+          <!-- {% else %} -->
+          <td>{{ month_goal.title|default:"未設定" }}</td>
+          <!-- {% endif %} {% endfor %} -->
+          <td>{{ month_goal.status }}</td>
+        </tr>
+        {% empty %}
+          <tr>
+            <td colspan="3">未設定</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+      <!-- {% else %}
+      <p>未設定</p>
+      {% endif %} {% else %}
+      <p>未設定</p>
+      {% endif %} -->
+    </table>
+  </div>
+</div>
 
-    function saveGoal(year) {
-        let newTitle = document.getElementById("goal-input").value;
-
-        fetch(`/goal/year_goal/${year}/edit/`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "X-CSRFToken": "{{ csrf_token }}"
-            },
-            body: JSON.stringify({ title: newTitle, year: year })
-        })
-        .then(response => response.json().then(data => ({ status: response.status, body: data })))
-        .then(({ status, body }) => {
-            if (status === 200) {
-                console.log('Success:', body.message);
-                document.getElementById("year-goal-text").textContent = newTitle;
-                document.getElementById("error-message").textContent = "";
-                toggleEdit();
-            } else {
-                // バリデーションエラーを投げる
-                throw body.error;
-            }
-        })
-        .catch(error => {
-            console.error('Error:', error);
-            document.getElementById("error-message").textContent = error.title ? error.title.join(", ") : "保存に失敗しました";
-        });
-    }
-</script>
-</html>
+{% endblock content %} {% block script %}
+<script src="{% static 'js/year_goal_detail.js' %}"></script>
+{% endblock script %}

--- a/goal/templates/year_goal_detail.html
+++ b/goal/templates/year_goal_detail.html
@@ -22,13 +22,16 @@
       <p id="error-message" style="color: red"></p>
       <!-- エラー表示用 -->
     </div>
+    {% else %}
+    <p>年目標が設定されていません。</p>
+    {% endif %}
   </div>
 
   <!-- 月目標リスト -->
   <div class="month-goal-box">
     <h2>月次目標</h2>
+    {% if month_goals %}
     <table>
-      <!-- {% if month_goals %} -->
       <thead>
         <tr>
           <th>月</th>
@@ -38,30 +41,23 @@
       </thead>
       <tbody>
         {% for month_goal in month_goals %}
-        <!-- {% if month_goal.title %} -->
         <tr>
-          <!-- <td>{{ month_goal.month }}: {{ month_goal.title }}</td> -->
           <td>{{ month_goal.month }}</td>
-          <!-- {% else %} -->
           <td>{{ month_goal.title|default:"未設定" }}</td>
-          <!-- {% endif %} {% endfor %} -->
           <td>{{ month_goal.status }}</td>
         </tr>
         {% empty %}
-          <tr>
-            <td colspan="3">未設定</td>
-          </tr>
+        <tr>
+          <td colspan="3">未設定</td>
+        </tr>
         {% endfor %}
       </tbody>
-      <!-- {% else %}
-      <p>未設定</p>
-      {% endif %} {% else %}
-      <p>未設定</p>
-      {% endif %} -->
     </table>
+    {% else %}
+    <p>月目標がありません。</p>
+    {% endif %}
   </div>
 </div>
-
 {% endblock content %} {% block script %}
 <script src="{% static 'js/year_goal_detail.js' %}"></script>
 {% endblock script %}

--- a/goal/templates/year_goal_detail.html
+++ b/goal/templates/year_goal_detail.html
@@ -13,13 +13,22 @@
       <button class="edit-button" onclick="toggleEdit()">編集</button>
     </div>
     <!-- 編集モード（非表示） -->
-    <div id="year-goal-form" style="display: none">
-      <input type="text" id="goal-input" value="{{ year_goal.title }}" />
-      <button class="save-button" onclick="saveGoal({{ year_goal.year.year }})">
-        保存
-      </button>
-      <button class="cancel-button" onclick="toggleEdit()">キャンセル</button>
-      <p id="error-message" style="color: red"></p>
+    <div class="year-goal-item">
+      <div id="year-goal-form" style="display: none">
+        <input type="text" id="goal-input" value="{{ year_goal.title }}" />
+        <div class="goal-buttons">
+          <button
+            class="save-button"
+            onclick="saveGoal({{ year_goal.year.year }})"
+          >
+            保存
+          </button>
+          <button class="cancel-button" onclick="toggleEdit()">
+            キャンセル
+          </button>
+          <p id="error-message" style="color: red"></p>
+        </div>
+      </div>
       <!-- エラー表示用 -->
     </div>
     {% else %}
@@ -52,7 +61,15 @@
             </a>
           </td>
           <td>{{ month_goal.title|default:"未設定" }}</td>
-          <td>{{ month_goal.status }}</td>
+          <td>
+            {% if month_goal.status == 0 %}
+              未達成
+            {% elif month_goal.status == 1 %}
+              達成
+            {% else %}
+              未達成
+            {% endif %}
+          </td>
         </tr>
         {% empty %}
         <tr>
@@ -101,46 +118,52 @@
 </div>
 {% endblock content %} {% block script %}
 <script>
-    function toggleEdit() {
-        let displayDiv = document.getElementById("year-goal-display");
-        let formDiv = document.getElementById("year-goal-form");
+  function toggleEdit() {
+    let displayDiv = document.getElementById("year-goal-display");
+    let formDiv = document.getElementById("year-goal-form");
 
-        if (displayDiv.style.display === "none") {
-            displayDiv.style.display = "block";
-            formDiv.style.display = "none";
+    if (displayDiv.style.display === "none") {
+      displayDiv.style.display = "block";
+      formDiv.style.display = "none";
+    } else {
+      displayDiv.style.display = "none";
+      formDiv.style.display = "block";
+    }
+  }
+
+  function saveGoal(year) {
+    let newTitle = document.getElementById("goal-input").value;
+
+    fetch(`/goal/year_goal/${year}/edit/`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": "{{ csrf_token }}",
+      },
+      body: JSON.stringify({ title: newTitle, year: year }),
+    })
+      .then((response) =>
+        response
+          .json()
+          .then((data) => ({ status: response.status, body: data }))
+      )
+      .then(({ status, body }) => {
+        if (status === 200) {
+          console.log("Success:", body.message);
+          document.getElementById("year-goal-text").textContent = newTitle;
+          document.getElementById("error-message").textContent = "";
+          toggleEdit();
         } else {
-            displayDiv.style.display = "none";
-            formDiv.style.display = "block";
+          // バリデーションエラーを投げる
+          throw body.error;
         }
-    }
-
-    function saveGoal(year) {
-        let newTitle = document.getElementById("goal-input").value;
-
-        fetch(`/goal/year_goal/${year}/edit/`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "X-CSRFToken": "{{ csrf_token }}"
-            },
-            body: JSON.stringify({ title: newTitle, year: year })
-        })
-        .then(response => response.json().then(data => ({ status: response.status, body: data })))
-        .then(({ status, body }) => {
-            if (status === 200) {
-                console.log('Success:', body.message);
-                document.getElementById("year-goal-text").textContent = newTitle;
-                document.getElementById("error-message").textContent = "";
-                toggleEdit();
-            } else {
-                // バリデーションエラーを投げる
-                throw body.error;
-            }
-        })
-        .catch(error => {
-            console.error('Error:', error);
-            document.getElementById("error-message").textContent = error.title ? error.title.join(", ") : "保存に失敗しました";
-        });
-    }
+      })
+      .catch((error) => {
+        console.error("Error:", error);
+        document.getElementById("error-message").textContent = error.title
+          ? error.title.join(", ")
+          : "保存に失敗しました";
+      });
+  }
 </script>
 {% endblock script %}

--- a/goal/templates/year_goal_detail.html
+++ b/goal/templates/year_goal_detail.html
@@ -43,6 +43,8 @@
         {% for month_goal in month_goals %}
         <tr>
           <td>
+            <!-- get_monthly_goals_for_year()により、monthが文字列"n月"でreturnされる。|slice:':-1' で月を削除 -->
+            <!-- |add:0 を使って文字列を整数に変換 -->
             <a
               href="{% url 'goal:month_goal_detail' month_goal.month|slice:':-1'|add:0 %}"
             >

--- a/goal/templates/year_goal_detail.html
+++ b/goal/templates/year_goal_detail.html
@@ -131,10 +131,10 @@
     }
   }
 
-  function saveGoal(year) {
+  async function saveGoal(year) {
     let newTitle = document.getElementById("goal-input").value;
 
-    fetch(`/goal/year_goal/${year}/edit/`, {
+    await fetch(`/goal/year_goal/${year}/edit/`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -149,7 +149,7 @@
       )
       .then(({ status, body }) => {
         if (status === 200) {
-          console.log("Success:", body.message);
+          console.log("Success:", body);
           document.getElementById("year-goal-text").textContent = newTitle;
           document.getElementById("error-message").textContent = "";
           toggleEdit();

--- a/goal/templates/year_goal_detail.html
+++ b/goal/templates/year_goal_detail.html
@@ -84,5 +84,47 @@
   </div>
 </div>
 {% endblock content %} {% block script %}
-<script src="{% static 'js/year_goal_detail.js' %}"></script>
+<script>
+    function toggleEdit() {
+        let displayDiv = document.getElementById("year-goal-display");
+        let formDiv = document.getElementById("year-goal-form");
+
+        if (displayDiv.style.display === "none") {
+            displayDiv.style.display = "block";
+            formDiv.style.display = "none";
+        } else {
+            displayDiv.style.display = "none";
+            formDiv.style.display = "block";
+        }
+    }
+
+    function saveGoal(year) {
+        let newTitle = document.getElementById("goal-input").value;
+
+        fetch(`/goal/year_goal/${year}/edit/`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRFToken": "{{ csrf_token }}"
+            },
+            body: JSON.stringify({ title: newTitle, year: year })
+        })
+        .then(response => response.json().then(data => ({ status: response.status, body: data })))
+        .then(({ status, body }) => {
+            if (status === 200) {
+                console.log('Success:', body.message);
+                document.getElementById("year-goal-text").textContent = newTitle;
+                document.getElementById("error-message").textContent = "";
+                toggleEdit();
+            } else {
+                // バリデーションエラーを投げる
+                throw body.error;
+            }
+        })
+        .catch(error => {
+            console.error('Error:', error);
+            document.getElementById("error-message").textContent = error.title ? error.title.join(", ") : "保存に失敗しました";
+        });
+    }
+</script>
 {% endblock script %}

--- a/goal/views/year_goal/year_goal_detail_views.py
+++ b/goal/views/year_goal/year_goal_detail_views.py
@@ -10,6 +10,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from goal.models import YearGoal
 from goal.models.month_goal import MonthGoal
 from django.core.paginator import Paginator
+from django.http import JsonResponse
 
 
 logger = logging.getLogger(__name__)

--- a/goal/views/year_goal/year_goal_detail_views.py
+++ b/goal/views/year_goal/year_goal_detail_views.py
@@ -9,6 +9,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 
 from goal.models import YearGoal
 from goal.models.month_goal import MonthGoal
+from django.core.paginator import Paginator
 
 
 logger = logging.getLogger(__name__)
@@ -62,5 +63,14 @@ class YearGoalDetailView(LoginRequiredMixin, DetailView):
 
         # year_goal.id をキーとして月次目標を取得し、コンテキストに追加
         context["month_goals"] = MonthGoal.get_monthly_goals_for_year(year_goal_id=year_goal.id)
+
+        # 今年の目標（すべて取得 & ページネーション）
+        month_goals = MonthGoal.get_monthly_goals_for_year(year_goal_id=year_goal.id)
+        paginator = Paginator(month_goals, 6)  # １ページあたりの件数
+        page_number = self.request.GET.get(
+            "page"
+        )  # URLのパラメータから現在のページ番号を取得
+        page_obj = paginator.get_page(page_number)  # 指定ページのオブジェクトを返す
+        context["month_goals"] = page_obj
 
         return context

--- a/static/css/year_goal_detail.css
+++ b/static/css/year_goal_detail.css
@@ -1,0 +1,91 @@
+@charset "utf-8";
+@import url("https://fonts.googleapis.com/css2?family=Kaisei+Opti:wght@400;700&display=swap");
+
+body {
+    background: linear-gradient(to bottom, #4A6FA5, #2E3B55);
+    font-family: "Kaisei Opti", serif;
+    color: #ffffff;
+    text-align: center;
+    background-attachment: fixed;
+    overflow: hidden;
+}
+
+/* 全体レイアウト */
+.year-goal-container {
+    width: 80%;
+    margin: auto;
+    padding: 20px;
+}
+
+/* 年目標エリア */
+.year-goal-box {
+    background: #ffffff;
+    color: #454749;
+    padding: 20px;
+    border-radius: 10px;
+    margin-bottom: 20px;
+}
+
+.year-goal-box h2 {
+    margin-bottom: 10px;
+}
+
+#year-goal-display {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.edit-button {
+    background: transparent;
+    border: none;
+    font-size: 18px;
+    cursor: pointer;
+}
+
+/* 月目標リスト */
+.month-goal-box {
+    background: #ffffff;
+    color: #454749;
+    padding: 20px;
+    border-radius: 10px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+
+th, td {
+    border: 1px solid #ccc;
+    padding: 10px;
+    text-align: center;
+}
+
+th {
+    background: #2E3B55;
+    color: white;
+}
+
+/* ボタン */
+button {
+    border: 1px solid #ccc;
+    padding: 5px 10px;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.save-button {
+    background: #4CAF50;
+    color: white;
+}
+
+.cancel-button {
+    background: #f44336;
+    color: white;
+}
+
+.error-text {
+    color: red;
+}

--- a/static/css/year_goal_detail.css
+++ b/static/css/year_goal_detail.css
@@ -30,19 +30,29 @@ body {
     padding: 20px;
     border-radius: 10px;
     margin-bottom: 20px;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
 }
 
 .year-goal-box h2 {
     margin-bottom: 10px;
+    display: flex;
 }
 
+/* 年目標の表示モード */
 #year-goal-display {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
+    width: 100%;
+    position: relative;
 }
 
 .edit-button {
+    position: absolute;
+    right: 10px;
+    bottom: 10px;
     background: transparent;
     border: 1px solid #507FA9;
     color: #507FA9;
@@ -50,7 +60,38 @@ body {
     font-size: 18px;
     cursor: pointer;
     padding: 5px 10px;
+}
+
+.year-goal-item {
+    flex-shrink: 1;
+}
+
+/* 保存・キャンセルボタンの配置 */
+.goal-buttons {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+    justify-content: flex-end;
+    align-items: flex-end;
+}
+
+.save-button {
+    background-color: transparent;
+    padding: 8px 12px;
     cursor: pointer;
+    border: 1px solid #BB3A1E;
+    color: #BB3A1E;
+    border-radius: 10px;
+}
+
+.cancel-button {
+    background-color: transparent;
+    padding: 8px 12px;
+    cursor: pointer;
+    border: 1px solid #3C6C76;
+    color: #3C6C76;
+    border-radius: 10px;
+    background: #ffffff90;
 }
 
 /* 月目標リスト */
@@ -84,16 +125,6 @@ button {
     padding: 5px 10px;
     border-radius: 5px;
     cursor: pointer;
-}
-
-.save-button {
-    background: #4CAF50;
-    color: white;
-}
-
-.cancel-button {
-    background: #f44336;
-    color: white;
 }
 
 .error-text {

--- a/static/css/year_goal_detail.css
+++ b/static/css/year_goal_detail.css
@@ -1,6 +1,12 @@
 @charset "utf-8";
 @import url("https://fonts.googleapis.com/css2?family=Kaisei+Opti:wght@400;700&display=swap");
 
+html {
+    height: 100svh;
+    margin: 0;
+    padding: 0;
+}
+
 body {
     background: linear-gradient(to bottom, #4A6FA5, #2E3B55);
     font-family: "Kaisei Opti", serif;
@@ -14,7 +20,7 @@ body {
 .year-goal-container {
     width: 80%;
     margin: auto;
-    padding: 20px;
+    padding: 50px;
 }
 
 /* 年目標エリア */
@@ -38,8 +44,12 @@ body {
 
 .edit-button {
     background: transparent;
-    border: none;
+    border: 1px solid #507FA9;
+    color: #507FA9;
+    border-radius: 10px;
     font-size: 18px;
+    cursor: pointer;
+    padding: 5px 10px;
     cursor: pointer;
 }
 
@@ -88,4 +98,31 @@ button {
 
 .error-text {
     color: red;
+}
+
+.logout {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+}
+
+.logout-button {
+    padding: 5px 10px;
+    background-color: transparent;
+    border: 1px solid #E5D99B;
+    color: #E5D99B;
+    border-radius: 10px;
+    cursor: pointer;
+}
+
+.home-button {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    padding: 5px 10px;
+    background-color: transparent;
+    border: 1px solid #E5D99B;
+    color: #E5D99B;
+    border-radius: 10px;
+    cursor: pointer;
 }

--- a/static/js/year_goal_detail.js
+++ b/static/js/year_goal_detail.js
@@ -12,21 +12,31 @@ function toggleEdit() {
   }
 }
 
+// CSRFトークンを取得する関数
+function getCsrfToken() {
+  let csrfTokenElement = document.querySelector("[name=csrfmiddlewaretoken]");
+  return csrfTokenElement ? csrfTokenElement.value : "";
+}
+
 // 年目標の保存処理
 function saveGoal(year) {
   let newTitle = document.getElementById("goal-input").value;
+  let csrfToken = getCsrfToken(); // CSRFトークンを取得
 
   fetch(`/goal/year_goal/${year}/edit/`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-CSRFToken": "{{ csrf_token }}",
+      "X-CSRFToken": csrfToken,
     },
     body: JSON.stringify({ title: newTitle, year: year }),
   })
-    .then((response) =>
-      response.json().then((data) => ({ status: response.status, body: data }))
-    )
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+      return response.json();
+    })
     .then(({ status, body }) => {
       if (status === 200) {
         console.log("Success:", body.message);
@@ -35,7 +45,7 @@ function saveGoal(year) {
         toggleEdit();
       } else {
         // バリデーションエラーを投げる
-        throw body.error;
+        throw new Error(body.error || "保存に失敗しました");
       }
     })
     .catch((error) => {
@@ -44,9 +54,4 @@ function saveGoal(year) {
         ? error.title.join(", ")
         : "保存に失敗しました";
     });
-}
-
-// CSRFトークンを取得する関数 追加
-function getCsrfToken() {
-    return document.querySelector("[name=csrfmiddlewaretoken]").value;
 }

--- a/static/js/year_goal_detail.js
+++ b/static/js/year_goal_detail.js
@@ -1,0 +1,52 @@
+// 年目標の編集切り替え
+function toggleEdit() {
+  let displayDiv = document.getElementById("year-goal-display");
+  let formDiv = document.getElementById("year-goal-form");
+
+  if (displayDiv.style.display === "none") {
+    displayDiv.style.display = "block";
+    formDiv.style.display = "none";
+  } else {
+    displayDiv.style.display = "none";
+    formDiv.style.display = "block";
+  }
+}
+
+// 年目標の保存処理
+function saveGoal(year) {
+  let newTitle = document.getElementById("goal-input").value;
+
+  fetch(`/goal/year_goal/${year}/edit/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": "{{ csrf_token }}",
+    },
+    body: JSON.stringify({ title: newTitle, year: year }),
+  })
+    .then((response) =>
+      response.json().then((data) => ({ status: response.status, body: data }))
+    )
+    .then(({ status, body }) => {
+      if (status === 200) {
+        console.log("Success:", body.message);
+        document.getElementById("year-goal-text").textContent = newTitle;
+        document.getElementById("error-message").textContent = "";
+        toggleEdit();
+      } else {
+        // バリデーションエラーを投げる
+        throw body.error;
+      }
+    })
+    .catch((error) => {
+      console.error("Error:", error);
+      document.getElementById("error-message").textContent = error.title
+        ? error.title.join(", ")
+        : "保存に失敗しました";
+    });
+}
+
+// CSRFトークンを取得する関数 追加
+function getCsrfToken() {
+    return document.querySelector("[name=csrfmiddlewaretoken]").value;
+}

--- a/staticfiles/css/year_goal_detail.css
+++ b/staticfiles/css/year_goal_detail.css
@@ -7,6 +7,7 @@ body {
     color: #ffffff;
     text-align: center;
     background-attachment: fixed;
+    overflow: hidden;
 }
 
 /* 全体レイアウト */

--- a/staticfiles/css/year_goal_detail.css
+++ b/staticfiles/css/year_goal_detail.css
@@ -1,0 +1,90 @@
+@charset "utf-8";
+@import url("https://fonts.googleapis.com/css2?family=Kaisei+Opti:wght@400;700&display=swap");
+
+body {
+    background: linear-gradient(to bottom, #4A6FA5, #2E3B55);
+    font-family: "Kaisei Opti", serif;
+    color: #ffffff;
+    text-align: center;
+    background-attachment: fixed;
+}
+
+/* 全体レイアウト */
+.year-goal-container {
+    width: 80%;
+    margin: auto;
+    padding: 20px;
+}
+
+/* 年目標エリア */
+.year-goal-box {
+    background: #ffffff;
+    color: #454749;
+    padding: 20px;
+    border-radius: 10px;
+    margin-bottom: 20px;
+}
+
+.year-goal-box h2 {
+    margin-bottom: 10px;
+}
+
+#year-goal-display {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.edit-button {
+    background: transparent;
+    border: none;
+    font-size: 18px;
+    cursor: pointer;
+}
+
+/* 月目標リスト */
+.month-goal-box {
+    background: #ffffff;
+    color: #454749;
+    padding: 20px;
+    border-radius: 10px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+
+th, td {
+    border: 1px solid #ccc;
+    padding: 10px;
+    text-align: center;
+}
+
+th {
+    background: #2E3B55;
+    color: white;
+}
+
+/* ボタン */
+button {
+    border: 1px solid #ccc;
+    padding: 5px 10px;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.save-button {
+    background: #4CAF50;
+    color: white;
+}
+
+.cancel-button {
+    background: #f44336;
+    color: white;
+}
+
+.error-text {
+    color: red;
+}

--- a/staticfiles/css/year_goal_detail.css
+++ b/staticfiles/css/year_goal_detail.css
@@ -30,19 +30,29 @@ body {
     padding: 20px;
     border-radius: 10px;
     margin-bottom: 20px;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
 }
 
 .year-goal-box h2 {
     margin-bottom: 10px;
+    display: flex;
 }
 
+/* 年目標の表示モード */
 #year-goal-display {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
+    width: 100%;
+    position: relative;
 }
 
 .edit-button {
+    position: absolute;
+    right: 10px;
+    bottom: 10px;
     background: transparent;
     border: 1px solid #507FA9;
     color: #507FA9;
@@ -50,7 +60,38 @@ body {
     font-size: 18px;
     cursor: pointer;
     padding: 5px 10px;
+}
+
+.year-goal-item {
+    flex-shrink: 1;
+}
+
+/* 保存・キャンセルボタンの配置 */
+.goal-buttons {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+    justify-content: flex-end;
+    align-items: flex-end;
+}
+
+.save-button {
+    background-color: transparent;
+    padding: 8px 12px;
     cursor: pointer;
+    border: 1px solid #BB3A1E;
+    color: #BB3A1E;
+    border-radius: 10px;
+}
+
+.cancel-button {
+    background-color: transparent;
+    padding: 8px 12px;
+    cursor: pointer;
+    border: 1px solid #3C6C76;
+    color: #3C6C76;
+    border-radius: 10px;
+    background: #ffffff90;
 }
 
 /* 月目標リスト */
@@ -84,16 +125,6 @@ button {
     padding: 5px 10px;
     border-radius: 5px;
     cursor: pointer;
-}
-
-.save-button {
-    background: #4CAF50;
-    color: white;
-}
-
-.cancel-button {
-    background: #f44336;
-    color: white;
 }
 
 .error-text {

--- a/staticfiles/css/year_goal_detail.css
+++ b/staticfiles/css/year_goal_detail.css
@@ -1,6 +1,12 @@
 @charset "utf-8";
 @import url("https://fonts.googleapis.com/css2?family=Kaisei+Opti:wght@400;700&display=swap");
 
+html {
+    height: 100svh;
+    margin: 0;
+    padding: 0;
+}
+
 body {
     background: linear-gradient(to bottom, #4A6FA5, #2E3B55);
     font-family: "Kaisei Opti", serif;
@@ -14,7 +20,7 @@ body {
 .year-goal-container {
     width: 80%;
     margin: auto;
-    padding: 20px;
+    padding: 50px;
 }
 
 /* 年目標エリア */
@@ -38,8 +44,12 @@ body {
 
 .edit-button {
     background: transparent;
-    border: none;
+    border: 1px solid #507FA9;
+    color: #507FA9;
+    border-radius: 10px;
     font-size: 18px;
+    cursor: pointer;
+    padding: 5px 10px;
     cursor: pointer;
 }
 
@@ -88,4 +98,31 @@ button {
 
 .error-text {
     color: red;
+}
+
+.logout {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+}
+
+.logout-button {
+    padding: 5px 10px;
+    background-color: transparent;
+    border: 1px solid #E5D99B;
+    color: #E5D99B;
+    border-radius: 10px;
+    cursor: pointer;
+}
+
+.home-button {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    padding: 5px 10px;
+    background-color: transparent;
+    border: 1px solid #E5D99B;
+    color: #E5D99B;
+    border-radius: 10px;
+    cursor: pointer;
 }

--- a/staticfiles/js/year_goal_detail.js
+++ b/staticfiles/js/year_goal_detail.js
@@ -1,0 +1,52 @@
+// 年目標の編集切り替え
+function toggleEdit() {
+  let displayDiv = document.getElementById("year-goal-display");
+  let formDiv = document.getElementById("year-goal-form");
+
+  if (displayDiv.style.display === "none") {
+    displayDiv.style.display = "block";
+    formDiv.style.display = "none";
+  } else {
+    displayDiv.style.display = "none";
+    formDiv.style.display = "block";
+  }
+}
+
+// 年目標の保存処理
+function saveGoal(year) {
+  let newTitle = document.getElementById("goal-input").value;
+
+  fetch(`/goal/year_goal/${year}/edit/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": "{{ csrf_token }}",
+    },
+    body: JSON.stringify({ title: newTitle, year: year }),
+  })
+    .then((response) =>
+      response.json().then((data) => ({ status: response.status, body: data }))
+    )
+    .then(({ status, body }) => {
+      if (status === 200) {
+        console.log("Success:", body.message);
+        document.getElementById("year-goal-text").textContent = newTitle;
+        document.getElementById("error-message").textContent = "";
+        toggleEdit();
+      } else {
+        // バリデーションエラーを投げる
+        throw body.error;
+      }
+    })
+    .catch((error) => {
+      console.error("Error:", error);
+      document.getElementById("error-message").textContent = error.title
+        ? error.title.join(", ")
+        : "保存に失敗しました";
+    });
+}
+
+// CSRFトークンを取得する関数 追加
+function getCsrfToken() {
+    return document.querySelector("[name=csrfmiddlewaretoken]").value;
+}

--- a/staticfiles/js/year_goal_detail.js
+++ b/staticfiles/js/year_goal_detail.js
@@ -31,9 +31,12 @@ function saveGoal(year) {
     },
     body: JSON.stringify({ title: newTitle, year: year }),
   })
-    .then((response) =>
-      response.json().then((data) => ({ status: response.status, body: data }))
-    )
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+      return response.json();
+    })
     .then(({ status, body }) => {
       if (status === 200) {
         console.log("Success:", body.message);
@@ -42,7 +45,7 @@ function saveGoal(year) {
         toggleEdit();
       } else {
         // バリデーションエラーを投げる
-        throw body.error;
+        throw new Error(body.error || "保存に失敗しました");
       }
     })
     .catch((error) => {

--- a/staticfiles/js/year_goal_detail.js
+++ b/staticfiles/js/year_goal_detail.js
@@ -12,15 +12,22 @@ function toggleEdit() {
   }
 }
 
+// CSRFトークンを取得する関数
+function getCsrfToken() {
+  let csrfTokenElement = document.querySelector("[name=csrfmiddlewaretoken]");
+  return csrfTokenElement ? csrfTokenElement.value : "";
+}
+
 // 年目標の保存処理
 function saveGoal(year) {
   let newTitle = document.getElementById("goal-input").value;
+  let csrfToken = getCsrfToken(); // CSRFトークンを取得
 
   fetch(`/goal/year_goal/${year}/edit/`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-CSRFToken": "{{ csrf_token }}",
+      "X-CSRFToken": csrfToken,
     },
     body: JSON.stringify({ title: newTitle, year: year }),
   })
@@ -44,9 +51,4 @@ function saveGoal(year) {
         ? error.title.join(", ")
         : "保存に失敗しました";
     });
-}
-
-// CSRFトークンを取得する関数 追加
-function getCsrfToken() {
-    return document.querySelector("[name=csrfmiddlewaretoken]").value;
 }


### PR DESCRIPTION
## 目的
- year_goal_detail.htmlのデザインを完成させる

## 実装の概要/やったこと

- year_goal_detail.htmlのデザイン

## 保留/やらないこと

- <script>内のjsを、static/js/year_goal_detail.jsに切り出すこと。
- ファイルは作成したが、現状機能していない。切り出すとエラーが発生し、ここに時間をかける余裕がないため対応見送りとした。

## できるようになること（ユーザ目線）

- year_goal_detail.htmlにデザイン反映

## できなくなること（ユーザ目線）

- なし

## 動作確認

- [x] 見た目が最低限整う
- [x] 編集ボタンを押すと、編集モードに切り替わる。
- [x] 保存ボタンを押すと、年目標データベースに値を反映できる。
- [x] 関連リストは6件を基準に、ページネーションできる。　※最大で12データ（2ページ）しかないため、「最初へ」「最後へ」のリンクは消した。
- [x] 関連リストの月をクリックすると、```/goal/year_goal/month_goal/<int:month>/```に飛ぶ。
- [x] 関連リストの月（タイトル登録なし）をクリックすると、ホーム画面に飛ぶ。

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/71c25064-2b73-4b75-ba3d-472d0d9fa5a6" />

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/41bd9629-840f-461c-a2ec-c90773f3fd3f" />
↓
<img width="736" alt="image" src="https://github.com/user-attachments/assets/c5bcf7e4-09ee-4b24-9904-fd8a576cf1f9" />



## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #88 
- @
