### PR TITLE
Todoの詳細画面を作成 #95

### DIFF
--- a/goal/models/todo.py
+++ b/goal/models/todo.py
@@ -129,3 +129,32 @@ class Todos(models.Model):
         except Exception as e:
             logger.exception(f"[Todos] Unexpected error while marking todos as achieved for month_goal={month_goal.id}: {e}")
             return None
+
+    @classmethod
+    def get_specific_todo(cls, month_goal, todo_id):
+        """
+        指定されたTodoを取得する
+        Args:
+            month_goal (MonthGoal): 月目標
+            todo_id (int): Todoのid
+        Returns:
+            Todo or None: 該当するTodoが存在すれば Todos インスタンスを返し、存在しなければ None を返す
+        """
+        try:
+            return cls.objects.get(month_goal=month_goal, id=todo_id)
+        except cls.DoesNotExist as e:
+            # 目標が設定されていない場合、ログに記録して None を返す
+            logger.warning(f"[Todo] Not found: month_goal_id={month_goal.id}, todo_id={todo_id}. Error: {e}")
+            return None
+        except cls.MultipleObjectsReturned as e:
+            # データの整合性エラー（1つの年の1つの月に複数の目標が存在する）
+            logger.error(f"[MonthGoal] Data integrity issue: Multiple entries found for month_goal_id={month_goal.id}, todo_id={todo_id}. Error: {e}")
+            return None
+        except DatabaseError as e:
+            # データベース関連のエラー
+            logger.error(f"[MonthGoal] DatabaseError: month_goal_id={month_goal.id}, todo_id={todo_id}. Error: {e}")
+            return None
+        except Exception as e:
+            # 予期しないエラーのキャッチ
+            logger.exception(f"[MonthGoal] Unexpected error: month_goal_id={month_goal.id}, todo_id={todo_id}. Error: {e}")
+            return None

--- a/goal/templates/todo_detail.html
+++ b/goal/templates/todo_detail.html
@@ -6,6 +6,7 @@
     <title>Document</title>
 </head>
 <body>
-    
+    <div>{{todo.month_goal}}</div>
+    <div>{{todo.title}}</div>
 </body>
 </html>

--- a/goal/urls.py
+++ b/goal/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import HomeView, CreateYearGoalView, YearGoalDetailView, YearGoalUpdateView, MontGoalDetailView, MonthGoalAchieveView, TodoCreateView, UnachievedTodoCheckView, FeedbackView
+from .views import HomeView, CreateYearGoalView, YearGoalDetailView, YearGoalUpdateView, MontGoalDetailView, MonthGoalAchieveView, TodoCreateView, TodoDetailView, UnachievedTodoCheckView, FeedbackView
 
 
 # 名前空間を設定
@@ -26,6 +26,10 @@ urlpatterns = [
     path("year_goal/<int:year>/month_goal/<int:month>/achieve/", MonthGoalAchieveView.as_view(), name="month_goal_achieve"),
     # 月目標に紐づく未達成のTodoがあるか確認
     path("year_goal/<int:year>/month_goal/<int:month>/has_unachieved_todos/", UnachievedTodoCheckView.as_view(), name="has_unachieved_todos"),
+    # Todo詳細画面（年指定なし）
+    path("year_goal/month_goal/<int:month>/todo/<int:todo>", TodoDetailView.as_view(), name="todo_detail"),
+    # Todo詳細画面（年指定あり）
+    path("year_goal/<int:year>/month_goal/<int:month>/todo/<int:todo>", TodoDetailView.as_view(), name="todo_detail_specific_year"),
     path("", HomeView.as_view(), name="home"),
     path("feedback/", FeedbackView.as_view(), name="feedback"),
 ]

--- a/goal/views/__init__.py
+++ b/goal/views/__init__.py
@@ -6,4 +6,5 @@ from .month_goal.month_goal_detail_views import MontGoalDetailView
 from .todo.todo_create_views import TodoCreateView
 from .month_goal.month_goal_achieve_views import MonthGoalAchieveView
 from .todo.unachieved_todo_check_views import UnachievedTodoCheckView
+from .todo.todo_detail_views import TodoDetailView
 from .feedback import FeedbackView

--- a/goal/views/todo/todo_detail_views.py
+++ b/goal/views/todo/todo_detail_views.py
@@ -1,0 +1,79 @@
+import logging
+from datetime import date
+
+from django.views.generic import DetailView
+from django.contrib.auth.mixins import LoginRequiredMixin
+
+from django.contrib import messages
+from django.shortcuts import redirect
+from django.urls import reverse
+from goal.models.month_goal import MonthGoal
+from goal.models.todo import Todos
+from goal.models.year_goal import YearGoal
+
+logger = logging.getLogger(__name__)
+
+class TodoDetailView(LoginRequiredMixin, DetailView):
+    template_name = "todo_detail.html"
+    model = Todos
+    context_object_name = "todo"
+
+    def get_object(self):
+        """
+        URLのパスから年、月、Todo(id)を取得し、Todoを取得する
+        Returns:
+            Todos: 指定されたTodoが存在すれば Todos インスタンスを返す
+        """
+        year = self.kwargs.get("year", date.today().year)
+        month = self.kwargs.get("month")
+        todo_id = self.kwargs.get("todo")
+
+        # 年をdatetime.dateに変換
+        year_start_date = date(year, 1, 1)
+        # 指定された年の目標を取得
+        year_goal = YearGoal.get_year_goal_for_user(self.request.user, year_start_date)
+        if not year_goal:
+            logger.warning(f"[YearGoal] Not found: user_id={self.request.user.id}, year={year}")
+            return None
+
+        # URL パラメータに month が設定されているか確認
+        if not month:
+            logger.warning(f"Month not provided in URL: year={year}")
+            return None
+
+        # 月目標を取得
+        month_goal = MonthGoal.get_specific_month_goal(year_goal=year_goal, month=month)
+        if not month_goal:
+            logger.warning(f"[MonthGoal] Not found: user_id={self.request.user.id}, year_goal.id={year_goal.id}, month={month}")
+            return None
+
+        # Todo を取得
+        todo = Todos.get_specific_todo(month_goal=month_goal, todo_id=todo_id)
+
+        return todo
+
+    def get(self, request, *args, **kwargs):
+        """
+        GETリクエスト時に、目標が存在しない場合はリダイレクト
+        """
+        self.object = self.get_object()
+        if self.object is None:
+            year = self.kwargs.get("year", date.today().year)
+            month = self.kwargs.get("month")
+            todo_id = self.kwargs.get("todo")
+            messages.warning(request, f"{year}年の{month}月の指定したTodo（id={todo_id}）はまだ設定されていません。")
+            return redirect(reverse("goal:month_goal_detail_specific_year", kwargs={"year": year, "month": month}))
+
+        return super().get(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        """
+        テンプレートに渡すコンテキストデータを作成する
+
+        Returns:
+            dict: テンプレートに渡すコンテキストデータ
+        """
+        context = super().get_context_data(**kwargs)
+        return context
+
+

--- a/goal/views/todo/todo_detail_views.py
+++ b/goal/views/todo/todo_detail_views.py
@@ -18,15 +18,24 @@ class TodoDetailView(LoginRequiredMixin, DetailView):
     model = Todos
     context_object_name = "todo"
 
+    def get_kwargs(self):
+        """
+        URLパラメータから year、month、todo_id を取得する。
+        Returns:
+            tuple[int, int, int]: year、month、todo_id のタプル。
+        """
+        year = self.kwargs.get("year", date.today().year)
+        month = self.kwargs.get("month")
+        todo_id = self.kwargs.get("todo")
+        return year, month, todo_id
+
     def get_object(self):
         """
         URLのパスから年、月、Todo(id)を取得し、Todoを取得する
         Returns:
             Todos: 指定されたTodoが存在すれば Todos インスタンスを返す
         """
-        year = self.kwargs.get("year", date.today().year)
-        month = self.kwargs.get("month")
-        todo_id = self.kwargs.get("todo")
+        year, month, todo_id = self.get_kwargs()
 
         # 年をdatetime.dateに変換
         year_start_date = date(year, 1, 1)
@@ -58,9 +67,7 @@ class TodoDetailView(LoginRequiredMixin, DetailView):
         """
         self.object = self.get_object()
         if self.object is None:
-            year = self.kwargs.get("year", date.today().year)
-            month = self.kwargs.get("month")
-            todo_id = self.kwargs.get("todo")
+            year, month, todo_id = self.get_kwargs()
             messages.warning(request, f"{year}年の{month}月の指定したTodo（id={todo_id}）はまだ設定されていません。")
             return redirect(reverse("goal:month_goal_detail_specific_year", kwargs={"year": year, "month": month}))
 


### PR DESCRIPTION
## 目的
ToDo詳細画面で、指定されたTodoのデータを取得し、正しく表示できるようにしました。

## 実装の概要/やったこと

- TodoDetailView クラスを作成
（ToDo詳細画面のURLを叩いた際に、Todoを取得する処理を実装）

- model の Todos クラスに get_specific_todo メソッドを追加
（Todoを取得するメソッドを実装）

## 保留/やらないこと

特にないです

## できるようになること（ユーザ目線）

- ToDo詳細画面にアクセスすると、指定されたTodoを確認できるようになりました。


## できなくなること（ユーザ目線）

特にないです

## 動作確認

1. 年目標（今年）と指定した月に紐づくのTodoを表示
- [x] http://127.0.0.1/goal/year_goal/month_goal/2/todo/<int: todo> にアクセスすると、以下が表示されること
- Todoに紐づいている月目標
- Todoのタイトル

2. 年目標（指定）と指定した月に紐づくのTodoを表示
- [x] http://127.0.0.1/goal/year_goal/2025/month_goal/2/todo/<int: todo> にアクセスすると、以下が表示されること
- Todoに紐づいている月目標
- Todoのタイトル

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
