### PR TITLE
達成ボタンを押すことで、データベースの情報が更新できる（Todo: 詳細画面）

### DIFF
--- a/goal/models/todo.py
+++ b/goal/models/todo.py
@@ -159,6 +159,34 @@ class Todos(models.Model):
             logger.exception(f"[MonthGoal] Unexpected error: month_goal_id={month_goal.id}, todo_id={todo_id}. Error: {e}")
             return None
 
+    @classmethod
+    def get_todo(cls, todo_id):
+        """
+        指定されたTodoを取得する
+        Args:
+            todo_id (int): Todoのid
+        Returns:
+            Todo or None: 該当するTodoが存在すれば Todos インスタンスを返し、存在しなければ None を返す
+        """
+        try:
+            return cls.objects.get(id=todo_id)
+        except cls.DoesNotExist as e:
+            # 目標が設定されていない場合、ログに記録して None を返す
+            logger.warning(f"[Todo] Not found: todo_id={todo_id}. Error: {e}")
+            return None
+        except cls.MultipleObjectsReturned as e:
+            # データの整合性エラー（1つの年の1つの月に複数の目標が存在する）
+            logger.error(f"[Todo] Data integrity issue: Multiple entries found for todo_id={todo_id}. Error: {e}")
+            return None
+        except DatabaseError as e:
+            # データベース関連のエラー
+            logger.error(f"[Todo] DatabaseError: todo_id={todo_id}. Error: {e}")
+            return None
+        except Exception as e:
+            # 予期しないエラーのキャッチ
+            logger.exception(f"[Todo] Unexpected error: todo_id={todo_id}. Error: {e}")
+            return None
+
     def mark_as_achieved(self):
         """
         Todoを達成済みに変更する

--- a/goal/models/todo.py
+++ b/goal/models/todo.py
@@ -114,7 +114,7 @@ class Todos(models.Model):
             raise
 
     @classmethod
-    def mark_as_achieved(cls, month_goal):
+    def mark_as_achieved_for_goal(cls, month_goal):
         """
         指定された月目標に紐づく未達成のToDoを達成済みに変更する
         Args:
@@ -158,3 +158,17 @@ class Todos(models.Model):
             # 予期しないエラーのキャッチ
             logger.exception(f"[MonthGoal] Unexpected error: month_goal_id={month_goal.id}, todo_id={todo_id}. Error: {e}")
             return None
+
+    def mark_as_achieved(self):
+        """
+        Todoを達成済みに変更する
+        Raises:
+            Exception: データベースの保存に失敗した場合
+        """
+        try:
+            self.status = self.STATUS_ACHIEVED
+            self.save()
+            logger.info(f"[Todo] ID:{self.id} marked as achieved.")
+        except Exception as e:
+            logger.error(f"[Todo] Failed to mark Todo ID:{self.id} as achieved. Error: {e}")
+            raise

--- a/goal/templates/todo_detail.html
+++ b/goal/templates/todo_detail.html
@@ -14,7 +14,18 @@
       <!-- 表示モード -->
       <div id="todo-display">
         <span id="todo-text">{{todo.title}}</span>
-        <button class="edit-button" onclick="toggleEdit()">編集</button>
+          <div>
+            <button class="edit-button" onclick="toggleEdit()">編集</button>
+            <div id="achieve-button" style="display: {% if todo.status == 0 %}block{% else %}none{% endif %};">
+              <button class="achieve-button" onclick="markTodoAsAchieve({{ todo.month_goal.year_goal.year.year }}, {{ todo.month_goal.month }}, {{ todo.id }})">
+                達成済みにする
+              </button>
+            </div>
+            <div id="achieve-message" style="display: {% if todo.status == 1 %}block{% else %}none{% endif %};">
+              <p>達成</p>
+            </div>
+          </div>
+          <p id="error-message" style="color: red"></p>
       </div>
       <!-- 編集モード（非表示） -->
       <div class="todo-item">
@@ -111,6 +122,36 @@
       console.error("Error:", error);
       document.getElementById("error-message").textContent =
         error.message || "保存に失敗しました";
+    }
+  }
+
+  async function markTodoAsAchieve(year, month, todoId) {
+    try {
+      const response = await fetch(
+        `/goal/year_goal/${year}/month_goal/${month}/todo/${todoId}/achieve/`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRFToken": "{{ csrf_token }}",
+          },
+          body: JSON.stringify({ todo_id: todoId})
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to Achieve todo");
+      }
+
+      const data = await response.json()
+      console.log("Success", data)
+      document.getElementById("achieve-button").style.display = "none";
+      document.getElementById("achieve-message").style.display = "block";
+    } catch (error) {
+      console.error("Error:", error);
+      console.log(error.message)
+      document.getElementById("error-message").textContent =
+        error.message || "状態変更に失敗しました";
     }
   }
 </script>

--- a/goal/urls.py
+++ b/goal/urls.py
@@ -11,6 +11,7 @@ from .views import (
     TodoCreateView,
     TodoDetailView,
     TodoUpdateView,
+    TodoAchieveView,
     UnachievedTodoCheckView,
     FeedbackView,
     FeedbackGoodView,
@@ -100,6 +101,12 @@ urlpatterns = [
         "year_goal/<int:year>/month_goal/<int:month>/todo/<int:todo>/update/",
         TodoUpdateView.as_view(),
         name="todo_update_specific_year",
+    ),
+    # Todoの状態を達成に変更する
+    path(
+        "year_goal/<int:year>/month_goal/<int:month>/todo/<int:todo>/achieve/",
+        TodoAchieveView.as_view(),
+        name="todo_achieve",
     ),
     path("", HomeView.as_view(), name="home"),
     # フィードバック画面（bad_message）

--- a/goal/views/__init__.py
+++ b/goal/views/__init__.py
@@ -6,8 +6,9 @@ from .month_goal.month_goal_detail_views import MontGoalDetailView
 from .month_goal.month_goal_update_views import MonthGoalUpdateView
 from .month_goal.month_goal_achieve_views import MonthGoalAchieveView
 from .todo.todo_create_views import TodoCreateView
-from .todo.unachieved_todo_check_views import UnachievedTodoCheckView
 from .todo.todo_detail_views import TodoDetailView
 from .todo.todo_update_views import TodoUpdateView
+from .todo.todo_achive_views import TodoAchieveView
+from .todo.unachieved_todo_check_views import UnachievedTodoCheckView
 from .feedback import FeedbackView
 from .feedback_good import FeedbackGoodView

--- a/goal/views/month_goal/month_goal_achieve_views.py
+++ b/goal/views/month_goal/month_goal_achieve_views.py
@@ -63,7 +63,7 @@ class MonthGoalAchieveView(LoginRequiredMixin, UpdateView):
             return JsonResponse({"error": "Failed to mark month goal as achieved."}, status=500)
 
         # 未達成のTodoを達成済みに更新
-        update_todo_count = Todos.mark_as_achieved(month_goal=month_goal)
+        update_todo_count = Todos.mark_todos_as_achieved_for_goal(month_goal=month_goal)
         if update_todo_count > 0:
             logger.info(f"[Todos] Updated {update_todo_count} todos as achieved for month_goal={month_goal.id}")
         else:

--- a/goal/views/todo/todo_achive_views.py
+++ b/goal/views/todo/todo_achive_views.py
@@ -1,0 +1,62 @@
+import logging
+import json
+
+from django.views.generic import UpdateView
+from django.http import JsonResponse
+from django.contrib.auth.mixins import LoginRequiredMixin
+
+from goal.models.todo import Todos
+
+logger = logging.getLogger(__name__)
+
+class TodoAchieveView(LoginRequiredMixin, UpdateView):
+    model = Todos
+
+    def get_object(self, todo_id):
+        """
+        更新対象のTodoを取得する
+        Returns:
+            Todo: 指定されたTodoが存在すれば Todos インスタンスを返す
+        """
+
+        # 指定されたTodoを取得
+        todo = Todos.get_todo(todo_id=todo_id)
+        if not todo:
+            logger.warning(f"[MonthGoal] Not found: todo_id={todo_id}")
+            return None
+
+        return todo
+
+    def post(self, request, *args, **kwargs):
+        """
+        Todoを達成状態に更新するAPIエンドポイント
+        Args:
+            request (HttpRequest): クライアントからのリクエスト
+        Returns:
+            JsonResponse:
+                - 成功時: 更新処理が完了したことを返す (status=200)
+                - 失敗時: エラーメッセージを返す (status=400, 404, 500)
+        """
+        try:
+            # リクエストボディをJSONとして読み込む
+            data = json.loads(request.body)
+        except json.JSONDecodeError:
+            logger.warning("[TodoAchieveView] Invalid JSON format in request body")
+            return JsonResponse({"error": "Invalid JSON format"}, status=400)
+
+        todo_id = data.get("todo_id")
+        if todo_id is None:
+            logger.warning("[TodoAchieveView] todo_id is missing in request data")
+            return JsonResponse({"error": "todo_id is required"}, status=400)
+
+        todo = self.get_object(todo_id=todo_id)
+        if not todo:
+            return JsonResponse({"error": "Todo not found."}, status=404)
+
+        try:
+            # Todoを達成状態にする
+            todo.mark_as_achieved()
+            return JsonResponse({"success": "Successfully processed request"}, status=200)
+        except Exception as e:
+            logger.error(f"[Todo] Error marking todo {todo.id} as achieved: {e}")
+            return JsonResponse({"error": "Failed to mark todo as achieved."}, status=500)

--- a/staticfiles/css/todo_detail.css
+++ b/staticfiles/css/todo_detail.css
@@ -90,6 +90,17 @@ h1, h2, h3, h4, h5, h6 {
     padding: 5px 10px;
 }
 
+.achieve-button {
+    background: transparent;
+    border: 1px solid #a95050;
+    color: #a95050;
+    border-radius: 10px;
+    font-size: 18px;
+    cursor: pointer;
+    padding: 5px 10px;
+    margin-left: 5px;
+}
+
 .todo-item {
     flex-shrink: 1;
 }


### PR DESCRIPTION
## 目的
Todo標詳細画面で「達成」ボタンを押すと、該当するTodoのステータスが達成状態になるようにします。

## 実装の概要/やったこと

- `Todo` クラス
  - `get_todo` : 指定されたTodoを取得する
  - `mark_as_achieved` : Todoを達成済みに変更する
- 新規作成した View
  - `TodoAchieveView` : Todoを達成状態に変更する API

## 保留/やらないこと

- `todo_detail.html` の CSSなど調整を行えていません。
@Sen-Megaten4649 さん申し訳ないです🙇

## できるようになること（ユーザ目線）

- Todo標詳細画面で「達成」ボタンを押すと、該当するTodoのステータスが達成状になりました。

## できなくなること（ユーザ目線）

- 特にないです

## 動作確認

- [x] 未達成のTodoの状態が「達成」になること（status カラムが 0 → 1 に更新）

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
