### PR TITLE
達成ボタンを押すことで、データベースの情報が更新できる（月目標: ホーム画面）

### DIFF
--- a/goal/templates/home.html
+++ b/goal/templates/home.html
@@ -262,6 +262,7 @@ async function handleAchieveClick(monthGoal) {
       await markGoalAsAchieve(id, yearGoal, month);
       // モーダルを閉じる
       hideModal();
+      location.reload();
     };
     document.getElementById("cancel-button").onclick = function () {
       // モーダルを閉じる

--- a/goal/templates/home.html
+++ b/goal/templates/home.html
@@ -1,6 +1,48 @@
 {% extends "base.html" %} {% load static %} {% block title %} ホーム 
 {% endblock title %} {% block head %}
 <link rel="stylesheet" href="{% static 'css/home.css' %}" />
+<style>
+  /* モーダルのスタイル */
+  #modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    justify-content: center;
+    align-items: center;
+  }
+
+  #modal-content {
+    background: white;
+    color: #454749;
+    padding: 20px;
+    border-radius: 10px;
+    text-align: center;
+  }
+
+  .month-goal-modal-cancel {
+    border: 1px solid #3c6c76;
+    color: #3c6c76;
+    border-radius: 10px;
+    font-size: 18px;
+    cursor: pointer;
+    padding: 5px 10px;
+    background: transparent;
+  }
+
+  .month-goal-modal-complete {
+    border: 1px solid #bb3a1e;
+    color: #bb3a1e;
+    border-radius: 10px;
+    font-size: 18px;
+    cursor: pointer;
+    padding: 5px 10px;
+    background: transparent;
+  }
+</style>
 {% endblock head %} {% block content %}
 
 <div class="home-container">
@@ -53,7 +95,23 @@
           <a href="{% url 'goal:month_goal_detail' month_goal.month %}"
             ><button class="goal-detail">詳細</button></a
           >
-          <button class="goal-complete">達成</button>
+          <div
+            id="achieve-month-goal-button"
+            style="display: {% if month_goal.status == 0 %}block{% else %}none{% endif %};"
+          >
+            <button
+              class="goal-complete"
+              onClick="handleAchieveClick({{ month_goal.to_dict }})"
+            >
+              達成
+            </button>
+          </div>
+          <div
+            id="achieve-month-goal-message"
+            style="display: {% if month_goal.status == 0 %}none{% else %}block{% endif %};"
+          >
+            <p>達成</p>
+          </div>
         </div>
       </div>
       {% else %}
@@ -112,12 +170,105 @@
   </div>
 </div>
 
+<!-- モーダルの構造 -->
+<div id="modal">
+  <div id="modal-content">
+    <p>
+      この月目標には未達成のToDoがあります。強制的に達成にすると、下のToDoも一括で完了となります。よろしいですか？
+    </p>
+    <button class="month-goal-modal-complete" id="confirm-button">
+      はい、強制達成する
+    </button>
+    <button class="month-goal-modal-cancel" id="cancel-button">いいえ、キャンセル</button>
+  </div>
+</div>
+
 {% endblock content %} {% block script %}
 <script src="{% static 'js/home.js' %}"></script>
 <script>
 {% comment %} 年目標エリア {% endcomment %}
 
 {% comment %} 月目標エリア {% endcomment %}
+async function checkIfTodosAchieved(year, month) {
+  try {
+    const response = await fetch(
+      `/goal/year_goal/${year}/month_goal/${month}/has_unachieved_todos/`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch data");
+    }
+    const data = await response.json();
+    if (data) {
+      return data.has_unachieved_todos;
+    }
+    return false;
+  } catch (error) {
+    console.error("Error:", error);
+    document.getElementById("error-message").textContent =
+      error.message || "状態変更に失敗しました";
+  }
+}
+
+function hideModal() {
+  document.getElementById("modal").style.display = "none";
+}
+
+async function markGoalAsAchieve(id, yearGoal, month) {
+  try {
+    const response = await fetch(
+      `/goal/year_goal/${yearGoal.year}/month_goal/${month}/achieve/`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRFToken": "{{ csrf_token }}",
+        },
+        body: JSON.stringify({ month_id: id }),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to Achieve goal");
+    }
+
+    const data = await response.json();
+    console.log("Success:", data);
+    document.getElementById("achieve-month-goal-button").style.display = "none";
+    document.getElementById("achieve-month-goal-message").style.display = "block";
+  } catch (error) {
+    console.error("Error:", error);
+    document.getElementById("error-message").textContent =
+      error.message || "状態変更に失敗しました";
+  }
+}
+
+async function handleAchieveClick(monthGoal) {
+  const { id, month, yearGoal } = monthGoal;
+
+  const result = await checkIfTodosAchieved(yearGoal.year, month);
+  if (!result) {
+    markGoalAsAchieve(id, yearGoal, month);
+  } else {
+    // モーダルを表示
+    document.getElementById("modal").style.display = "flex";
+    document.getElementById("confirm-button").onclick = async function () {
+      await markGoalAsAchieve(id, yearGoal, month);
+      // モーダルを閉じる
+      hideModal();
+    };
+    document.getElementById("cancel-button").onclick = function () {
+      // モーダルを閉じる
+      hideModal();
+    };
+  }
+}
 
 {% comment %} Todoエリア {% endcomment %}
 async function markTodoAsAchieve(year, month, todoId) {

--- a/goal/templates/home.html
+++ b/goal/templates/home.html
@@ -1,48 +1,6 @@
 {% extends "base.html" %} {% load static %} {% block title %} ホーム 
 {% endblock title %} {% block head %}
 <link rel="stylesheet" href="{% static 'css/home.css' %}" />
-<style>
-  /* モーダルのスタイル */
-  #modal {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5);
-    display: none;
-    justify-content: center;
-    align-items: center;
-  }
-
-  #modal-content {
-    background: white;
-    color: #454749;
-    padding: 20px;
-    border-radius: 10px;
-    text-align: center;
-  }
-
-  .month-goal-modal-cancel {
-    border: 1px solid #3c6c76;
-    color: #3c6c76;
-    border-radius: 10px;
-    font-size: 18px;
-    cursor: pointer;
-    padding: 5px 10px;
-    background: transparent;
-  }
-
-  .month-goal-modal-complete {
-    border: 1px solid #bb3a1e;
-    color: #bb3a1e;
-    border-radius: 10px;
-    font-size: 18px;
-    cursor: pointer;
-    padding: 5px 10px;
-    background: transparent;
-  }
-</style>
 {% endblock head %} {% block content %}
 
 <div class="home-container">

--- a/goal/views/month_goal/month_goal_achieve_views.py
+++ b/goal/views/month_goal/month_goal_achieve_views.py
@@ -63,7 +63,7 @@ class MonthGoalAchieveView(LoginRequiredMixin, UpdateView):
             return JsonResponse({"error": "Failed to mark month goal as achieved."}, status=500)
 
         # 未達成のTodoを達成済みに更新
-        update_todo_count = Todos.mark_todos_as_achieved_for_goal(month_goal=month_goal)
+        update_todo_count = Todos.mark_as_achieved_for_goal(month_goal=month_goal)
         if update_todo_count > 0:
             logger.info(f"[Todos] Updated {update_todo_count} todos as achieved for month_goal={month_goal.id}")
         else:

--- a/static/css/home.css
+++ b/static/css/home.css
@@ -195,3 +195,44 @@ body {
   color: #bb3a1e;
   border-radius: 10px;
 }
+
+/* モーダルのスタイル */
+#modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  justify-content: center;
+  align-items: center;
+}
+
+#modal-content {
+  background: white;
+  color: #454749;
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+}
+
+.month-goal-modal-cancel {
+  border: 1px solid #3c6c76;
+  color: #3c6c76;
+  border-radius: 10px;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 5px 10px;
+  background: transparent;
+}
+
+.month-goal-modal-complete {
+  border: 1px solid #bb3a1e;
+  color: #bb3a1e;
+  border-radius: 10px;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 5px 10px;
+  background: transparent;
+}

--- a/staticfiles/css/home.css
+++ b/staticfiles/css/home.css
@@ -195,3 +195,44 @@ body {
   color: #bb3a1e;
   border-radius: 10px;
 }
+
+/* モーダルのスタイル */
+#modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  justify-content: center;
+  align-items: center;
+}
+
+#modal-content {
+  background: white;
+  color: #454749;
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+}
+
+.month-goal-modal-cancel {
+  border: 1px solid #3c6c76;
+  color: #3c6c76;
+  border-radius: 10px;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 5px 10px;
+  background: transparent;
+}
+
+.month-goal-modal-complete {
+  border: 1px solid #bb3a1e;
+  color: #bb3a1e;
+  border-radius: 10px;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 5px 10px;
+  background: transparent;
+}


### PR DESCRIPTION
## 目的
ホーム画面で月目標の「達成」ボタンを押すと、該当する月目標と紐づいている未達成のTodoのステータスが達成状態になるようにします。

## 実装の概要/やったこと
`home.html` で月目標の達成ボタンを押下した際に、月目標の達成APIを実行できるようにしました。

## 保留/やらないこと
CSSファイルへの記述がうまくいかなかったため、HTMLファイルに直接記載しています。

## できるようになること（ユーザ目線）
ホーム画面で月目標のステータスを達成状態にすることができるようになりました。

## できなくなること（ユーザ目線）

特にないです。

## 動作確認

1. 月目標に紐づく未達成の Todo がない場合
  - [x] 月目標の状態が「達成」になること（status カラムが 0 → 1 に更新）
2. 月目標に紐づく未達成の Todo が 1 個ある場合
  - [x] 確認のモーダルが表示されること
  - [x] 「はい、強制達成する」を押下すると以下が実行される
    - 月目標の状態が「達成」になる（status カラムが 0 → 1 に更新）
    - 紐づいていた未達成の Todo の状態も「達成」になる（status カラムが 0 → 1 に更新）
  - [x] 「いいえ、キャンセル」を押下すると、以下が維持される
    - 月目標の状態が「未達成」のまま
    - 紐づいている未達成の Todo の状態も「未達成」のまま  
3. 月目標に紐づく未達成の Todo が 5 個ある場合
  - [x] 確認のモーダルが表示されること
  - [x] 「はい、強制達成する」を押下すると以下が実行される
    - 月目標の状態が「達成」になる（status カラムが 0 → 1 に更新）
    - 紐づいていた未達成の Todo（5 個全て）の状態も「達成」になる（status カラムが 0 → 1 に更新）
  - [x] 「いいえ、キャンセル」を押下すると、以下が維持される
    - 月目標の状態が「未達成」のまま
    - 紐づいている未達成の Todo の状態も「未達成」のまま  

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
